### PR TITLE
Ajout route `GET /auth/fcplus/creationSession`

### DIFF
--- a/.env.oots.template
+++ b/.env.oots.template
@@ -1,5 +1,7 @@
-AVEC_ENVOI_COOKIE_SUR_HTTP= #autorise envoi du cookie de session par HTTP avec valeur true
-AVEC_REQUETE_PIECE_JUSTIFICATIVE= #active l'API /requete/pieceJustificative avec valeur true
+AVEC_ENVOI_COOKIE_SUR_HTTP= # autorise envoi du cookie de session par HTTP avec valeur true
+AVEC_REQUETE_PIECE_JUSTIFICATIVE= # active l'API /requete/pieceJustificative avec valeur true
+IDENTIFIANT_EIDAS= # identifiant eIDAS injecté dans les requêtes (tant qu'on ne sait pas le récupérer)
+URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr
 
 DELAI_MAX_ATTENTE_DOMIBUS= # délai maximum d'attente d'une réponse Domibus à une requête envoyée (en millisecondes)
 IDENTIFIANT_EXPEDITEUR_DOMIBUS= # identifiant expéditeur Domibus
@@ -7,14 +9,12 @@ SUFFIXE_IDENTIFIANTS_DOMIBUS= # suffixe à ajouter dans les trames EBMS, ex. oot
 TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS= # type d'identifiant expéditeur Domibus
 URL_BASE_DOMIBUS= # URL instance Domibus, ex. https://domibus.gouv.fr
 
+AVEC_AUTHENTIFICATION_EIDAS= # si renseigné à `true`, passe par le « bridge eIDAS » pour l'authentification
+CLE_PRIVEE_JWK_EN_BASE64= # Cle privée utilisée pour déchiffrer les infos utilisateur provenant de eIDAS (données au format JWK, chiffrées en base64)
 IDENTIFIANT_CLIENT_FCPLUS= # identifiant d'accès au serveur FC+
 SECRET_CLIENT_FCPLUS= # secret d'accès au serveur FC+
-URL_CONFIGURATION_OPEN_ID_FCPLUS= # URL accès aux informations de configuration Open ID de FranceConnect+
-
-CLE_PRIVEE_JWK_EN_BASE64= # Cle privée utilisée pour déchiffrer les infos utilisateur provenant de eIDAS (données au format JWK, chiffrées en base64)
 SECRET_JETON_SESSION= # secret utilisé pour chiffrer et déchiffrer le jeton stocké dans le cookie de session
-IDENTIFIANT_EIDAS= # identifiant eIDAS injecté dans les requêtes (tant qu'on ne sait pas le récupérer)
-URL_OOTS_FRANCE= # URL Serveur OOTS-France, ex. https://oots.gouv.fr
+URL_CONFIGURATION_OPEN_ID_FCPLUS= # URL accès aux informations de configuration Open ID de FranceConnect+
 URL_REDIRECTION_CONNEXION= # URL redirection après authentification FranceConnect+
 URL_REDIRECTION_DECONNEXION= # URL redirection après destruction session FranceConnect+
 

--- a/mockFCPlus.js
+++ b/mockFCPlus.js
@@ -66,11 +66,17 @@ app.use(express.urlencoded({ extended: true }));
 
 app.get('/', (_requete, reponse) => {
   reponse.json({
+    authorization_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/debut_session`,
     end_session_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/fin_session`,
     jwks_uri: `${process.env.URL_BASE_MOCK_FCPLUS}/jwks`,
     token_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/jeton`,
     userinfo_endpoint: `${process.env.URL_BASE_MOCK_FCPLUS}/userinfo`,
   });
+});
+
+app.get('/debut_session', (requete, reponse) => {
+  const etat = requete.params.state;
+  reponse.redirect(`${process.env.URL_REDIRECTION_CONNEXION}?state=${etat}&code=abcdef`);
 });
 
 app.get('/fin_session', (_requete, reponse) => {

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -4,6 +4,8 @@ const avecEnvoiCookieSurHTTP = () => process.env.AVEC_ENVOI_COOKIE_SUR_HTTP === 
 
 const clePriveeJWK = () => JSON.parse(atob(process.env.CLE_PRIVEE_JWK_EN_BASE64));
 
+const identifiantClient = () => process.env.IDENTIFIANT_CLIENT_FCPLUS;
+
 const identifiantEIDAS = () => process.env.IDENTIFIANT_EIDAS;
 
 const parametresRequeteJeton = () => ({
@@ -16,15 +18,19 @@ const secretJetonSession = () => new TextEncoder().encode(process.env.SECRET_JET
 
 const urlConfigurationOpenIdFCPlus = () => process.env.URL_CONFIGURATION_OPEN_ID_FCPLUS;
 
+const urlRedirectionConnexion = () => process.env.URL_REDIRECTION_CONNEXION;
+
 const urlRedirectionDeconnexion = () => process.env.URL_REDIRECTION_DECONNEXION;
 
 module.exports = {
   avecEnvoiCookieSurHTTP,
   avecRequetePieceJustificative,
   clePriveeJWK,
+  identifiantClient,
   identifiantEIDAS,
   parametresRequeteJeton,
   secretJetonSession,
   urlConfigurationOpenIdFCPlus,
+  urlRedirectionConnexion,
   urlRedirectionDeconnexion,
 };

--- a/src/adaptateurs/adaptateurEnvironnement.js
+++ b/src/adaptateurs/adaptateurEnvironnement.js
@@ -4,6 +4,8 @@ const avecEnvoiCookieSurHTTP = () => process.env.AVEC_ENVOI_COOKIE_SUR_HTTP === 
 
 const clePriveeJWK = () => JSON.parse(atob(process.env.CLE_PRIVEE_JWK_EN_BASE64));
 
+const fournisseurIdentiteSuggere = () => (process.env.AVEC_AUTHENTIFICATION_EIDAS === 'true' ? 'eidas-bridge' : '');
+
 const identifiantClient = () => process.env.IDENTIFIANT_CLIENT_FCPLUS;
 
 const identifiantEIDAS = () => process.env.IDENTIFIANT_EIDAS;
@@ -26,6 +28,7 @@ module.exports = {
   avecEnvoiCookieSurHTTP,
   avecRequetePieceJustificative,
   clePriveeJWK,
+  fournisseurIdentiteSuggere,
   identifiantClient,
   identifiantEIDAS,
   parametresRequeteJeton,

--- a/src/adaptateurs/adaptateurFranceConnectPlus.js
+++ b/src/adaptateurs/adaptateurFranceConnectPlus.js
@@ -32,6 +32,9 @@ const recupereInfosUtilisateurChiffrees = (jetonAcces) => configurationOpenIdFra
 const recupereURLClefsPubliques = () => configurationOpenIdFranceConnectPlus
   .then(({ jwks_uri: url }) => url);
 
+const urlCreationSession = () => configurationOpenIdFranceConnectPlus
+  .then(({ authorization_endpoint: url }) => url);
+
 const urlDestructionSession = () => configurationOpenIdFranceConnectPlus
   .then(({ end_session_endpoint: url }) => url);
 
@@ -39,5 +42,6 @@ module.exports = {
   recupereDonneesJetonAcces,
   recupereInfosUtilisateurChiffrees,
   recupereURLClefsPubliques,
+  urlCreationSession,
   urlDestructionSession,
 };

--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -1,3 +1,11 @@
+const redirigeDepuisNavigateur = (destination, reponse) => reponse.send(`
+<!DOCTYPE html>
+<html>
+<head><meta http-equiv="refresh" content="0; url='${destination}'"></head>
+<body></body>
+</html>
+`);
+
 const connexionFCPlus = (config, code, requete, reponse) => {
   const { adaptateurChiffrement, fabriqueSessionFCPlus } = config;
 
@@ -6,8 +14,8 @@ const connexionFCPlus = (config, code, requete, reponse) => {
   return fabriqueSessionFCPlus.nouvelleSession(code)
     .then((session) => session.enJSON())
     .then((infos) => adaptateurChiffrement.genereJeton(infos)
-      .then((jwt) => { requete.session.jeton = jwt; })
-      .then(() => reponse.json(infos)))
+      .then((jwt) => { requete.session.jeton = jwt; }))
+    .then(() => redirigeDepuisNavigateur('/', reponse))
     .catch((e) => reponse.status(502).json({ erreur: `Échec authentification (${e.message})` }));
 };
 

--- a/src/api/connexionFCPlus.js
+++ b/src/api/connexionFCPlus.js
@@ -1,3 +1,7 @@
+const stockeDansCookieSession = (infos, adaptateurChiffrement, requete) => adaptateurChiffrement
+  .genereJeton(infos)
+  .then((jwt) => { requete.session.jeton = jwt; });
+
 const redirigeDepuisNavigateur = (destination, reponse) => reponse.send(`
 <!DOCTYPE html>
 <html>
@@ -13,8 +17,7 @@ const connexionFCPlus = (config, code, requete, reponse) => {
 
   return fabriqueSessionFCPlus.nouvelleSession(code)
     .then((session) => session.enJSON())
-    .then((infos) => adaptateurChiffrement.genereJeton(infos)
-      .then((jwt) => { requete.session.jeton = jwt; }))
+    .then((infos) => stockeDansCookieSession(infos, adaptateurChiffrement, requete))
     .then(() => redirigeDepuisNavigateur('/', reponse))
     .catch((e) => reponse.status(502).json({ erreur: `Échec authentification (${e.message})` }));
 };

--- a/src/api/creationSessionFCPlus.js
+++ b/src/api/creationSessionFCPlus.js
@@ -1,0 +1,15 @@
+const creationSessionFCPlus = (config, requete, reponse) => {
+  const { adaptateurChiffrement, adaptateurEnvironnement, adaptateurFranceConnectPlus } = config;
+
+  const identifiantClient = adaptateurEnvironnement.identifiantClient();
+  const urlRedirectionConnexion = adaptateurEnvironnement.urlRedirectionConnexion();
+  const etat = adaptateurChiffrement.cleHachage(`${Math.random()}`);
+  const nonce = adaptateurChiffrement.cleHachage(`${Math.random()}`);
+
+  return adaptateurFranceConnectPlus.urlCreationSession()
+    .then((url) => reponse.redirect(
+      `${url}?scope=profile%20openid&acr_values=eidas2&claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}&prompt=login%20consent&response_type=code&client_id=${identifiantClient}&redirect_uri=${urlRedirectionConnexion}&state=${etat}&nonce=${nonce}`,
+    ));
+};
+
+module.exports = creationSessionFCPlus;

--- a/src/api/creationSessionFCPlus.js
+++ b/src/api/creationSessionFCPlus.js
@@ -8,7 +8,7 @@ const creationSessionFCPlus = (config, requete, reponse) => {
 
   return adaptateurFranceConnectPlus.urlCreationSession()
     .then((url) => reponse.redirect(
-      `${url}?scope=profile%20openid&acr_values=eidas2&claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}&prompt=login%20consent&response_type=code&client_id=${identifiantClient}&redirect_uri=${urlRedirectionConnexion}&state=${etat}&nonce=${nonce}`,
+      `${url}?scope=profile%20openid&acr_values=eidas2&claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}&prompt=login%20consent&response_type=code&idp_hint=${adaptateurEnvironnement.fournisseurIdentiteSuggere()}&client_id=${identifiantClient}&redirect_uri=${urlRedirectionConnexion}&state=${etat}&nonce=${nonce}`,
     ));
 };
 

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -32,7 +32,7 @@ const creeServeur = (config) => {
 
   app.use(cookieSession({
     maxAge: 15 * 60 * 1000,
-    name: 'jeton',
+    name: 'session',
     sameSite: true,
     secret: adaptateurEnvironnement.secretJetonSession(),
     secure: !adaptateurEnvironnement.avecEnvoiCookieSurHTTP(),

--- a/src/routes/routesAuth.js
+++ b/src/routes/routesAuth.js
@@ -2,6 +2,7 @@ const express = require('express');
 
 const connexionFCPlus = require('../api/connexionFCPlus');
 const deconnexionFCPlus = require('../api/deconnexionFCPlus');
+const creationSessionFCPlus = require('../api/creationSessionFCPlus');
 const destructionSessionFCPlus = require('../api/destructionSessionFCPlus');
 
 const routesAuth = (config) => {
@@ -56,6 +57,18 @@ const routesAuth = (config) => {
 
   routes.get('/fcplus/destructionSession', (...args) => middleware.renseigneUtilisateurCourant(...args), (requete, reponse) => (
     destructionSessionFCPlus(
+      {
+        adaptateurChiffrement,
+        adaptateurEnvironnement,
+        adaptateurFranceConnectPlus,
+      },
+      requete,
+      reponse,
+    )
+  ));
+
+  routes.get('/fcplus/creationSession', (requete, reponse) => (
+    creationSessionFCPlus(
       {
         adaptateurChiffrement,
         adaptateurEnvironnement,

--- a/src/vues/pageAccueil.mustache
+++ b/src/vues/pageAccueil.mustache
@@ -8,4 +8,5 @@
 {{/infosUtilisateur}}
 {{^infosUtilisateur}}
   <p>Pas d'utilisateur courant</p>
+  <a href="/auth/fcplus/creationSession">Connexion</a>
 {{/infosUtilisateur}}

--- a/test/api/connexionFCPlus.spec.js
+++ b/test/api/connexionFCPlus.spec.js
@@ -14,22 +14,8 @@ describe('Le requêteur de connexion FC+', () => {
     });
     requete.session = {};
     reponse.json = () => Promise.resolve();
+    reponse.redirect = () => Promise.resolve();
     reponse.status = () => reponse;
-  });
-
-  it('retourne les infos de la session FC+ en JSON', () => {
-    expect.assertions(1);
-
-    fabriqueSessionFCPlus.nouvelleSession = () => Promise.resolve({
-      enJSON: () => Promise.resolve({ infos: 'des infos' }),
-    });
-
-    reponse.json = (donnees) => {
-      expect(donnees).toEqual({ infos: 'des infos' });
-      return Promise.resolve();
-    };
-
-    return connexionFCPlus(config, 'unCode', requete, reponse);
   });
 
   it('conserve les infos utilisateurs dans un cookie de session', () => {

--- a/test/api/creationSessionFCPlus.spec.js
+++ b/test/api/creationSessionFCPlus.spec.js
@@ -1,0 +1,110 @@
+const creationSessionFCPlus = require('../../src/api/creationSessionFCPlus');
+
+describe('Le requêteur de création de session FC+', () => {
+  const adaptateurChiffrement = {};
+  const adaptateurEnvironnement = {};
+  const adaptateurFranceConnectPlus = {};
+  const config = { adaptateurChiffrement, adaptateurEnvironnement, adaptateurFranceConnectPlus };
+  const reponse = {};
+
+  const requete = {};
+
+  beforeEach(() => {
+    adaptateurChiffrement.cleHachage = () => '';
+    adaptateurEnvironnement.identifiantClient = () => '';
+    adaptateurEnvironnement.urlRedirectionConnexion = () => '';
+    adaptateurFranceConnectPlus.urlCreationSession = () => Promise.resolve('');
+  });
+
+  it('redirige vers serveur France Connect Plus', () => {
+    expect.assertions(1);
+    adaptateurFranceConnectPlus.urlCreationSession = () => Promise.resolve('http://example.com');
+
+    reponse.redirect = (url) => {
+      try {
+        expect(url).toMatch(/^http:\/\/example\.com\?/);
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return creationSessionFCPlus(config, requete, reponse);
+  });
+
+  it('ajoute des paramètres à la requête', () => {
+    expect.assertions(5);
+
+    reponse.redirect = (url) => {
+      try {
+        expect(url).toContain('scope=profile%20openid');
+        expect(url).toContain('acr_values=eidas2');
+        expect(url).toContain('claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}');
+        expect(url).toContain('prompt=login%20consent');
+        expect(url).toContain('response_type=code');
+
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return creationSessionFCPlus(config, requete, reponse);
+  });
+
+  it("ajoute l'identifiant client FC+ en paramètre", () => {
+    expect.assertions(1);
+
+    adaptateurEnvironnement.identifiantClient = () => '12345';
+
+    reponse.redirect = (url) => {
+      try {
+        expect(url).toContain('client_id=12345');
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return creationSessionFCPlus(config, requete, reponse);
+  });
+
+  it("ajoute l'URL de redirection post-login en paramètre", () => {
+    expect.assertions(1);
+
+    adaptateurEnvironnement.urlRedirectionConnexion = () => 'http://example.com';
+
+    reponse.redirect = (url) => {
+      try {
+        expect(url).toContain('redirect_uri=http://example.com');
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return creationSessionFCPlus(config, requete, reponse);
+  });
+
+  it('ajoute un état et un nonce en paramètres de la requête', () => {
+    expect.assertions(2);
+    let nbClesGenerees = 0;
+
+    adaptateurChiffrement.cleHachage = () => {
+      nbClesGenerees += 1;
+      return `12345-${nbClesGenerees}`;
+    };
+
+    reponse.redirect = (url) => {
+      try {
+        expect(url).toContain('state=12345-1');
+        expect(url).toContain('nonce=12345-2');
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return creationSessionFCPlus(config, requete, reponse);
+  });
+});

--- a/test/api/creationSessionFCPlus.spec.js
+++ b/test/api/creationSessionFCPlus.spec.js
@@ -11,6 +11,7 @@ describe('Le requêteur de création de session FC+', () => {
 
   beforeEach(() => {
     adaptateurChiffrement.cleHachage = () => '';
+    adaptateurEnvironnement.fournisseurIdentiteSuggere = () => '';
     adaptateurEnvironnement.identifiantClient = () => '';
     adaptateurEnvironnement.urlRedirectionConnexion = () => '';
     adaptateurFranceConnectPlus.urlCreationSession = () => Promise.resolve('');
@@ -33,7 +34,7 @@ describe('Le requêteur de création de session FC+', () => {
   });
 
   it('ajoute des paramètres à la requête', () => {
-    expect.assertions(5);
+    expect.assertions(6);
 
     reponse.redirect = (url) => {
       try {
@@ -42,6 +43,7 @@ describe('Le requêteur de création de session FC+', () => {
         expect(url).toContain('claims={%22id_token%22:{%22amr%22:{%22essential%22:true}}}');
         expect(url).toContain('prompt=login%20consent');
         expect(url).toContain('response_type=code');
+        expect(url).toContain('idp_hint=');
 
         return Promise.resolve();
       } catch (e) {
@@ -106,5 +108,23 @@ describe('Le requêteur de création de session FC+', () => {
     };
 
     return creationSessionFCPlus(config, requete, reponse);
+  });
+
+  describe('Si utilisation bridge eIDAS', () => {
+    it('renseigne le paramètre `idp_hint` avec la valeur `eidas-bridge`', () => {
+      expect.assertions(1);
+      adaptateurEnvironnement.fournisseurIdentiteSuggere = () => 'eidas-bridge';
+
+      reponse.redirect = (url) => {
+        try {
+          expect(url).toContain('idp_hint=eidas-bridge');
+          return Promise.resolve();
+        } catch (e) {
+          return Promise.reject(e);
+        }
+      };
+
+      return creationSessionFCPlus(config, requete, reponse);
+    });
   });
 });

--- a/test/routes/routesAuth.spec.js
+++ b/test/routes/routesAuth.spec.js
@@ -65,7 +65,7 @@ describe('Le serveur des routes `/auth`', () => {
             expect(reponse.headers).toHaveProperty('set-cookie');
             const valeurEnteteSetCookie = reponse
               .headers['set-cookie']
-              .find((h) => h.match(/jeton=/));
+              .find((h) => h.match(/session=/));
             expect(valeurEnteteSetCookie).not.toContain('secure');
           })
           .catch(leveErreur);
@@ -126,6 +126,27 @@ describe('Le serveur des routes `/auth`', () => {
       return axios.get(`http://localhost:${port}/auth/fcplus/destructionSession`)
         .then((reponse) => expect(reponse.request.path).toContain('id_token_hint=abcdef'))
         .catch(leveErreur);
+    });
+  });
+
+  describe('sur GET /auth/fcplus/creationSession', () => {
+    const verifieRedirection = (urlSource, urlDestination) => axios({
+      method: 'get',
+      url: urlSource,
+      maxRedirects: 0,
+    })
+      .catch(({ response }) => {
+        expect(response.status).toBe(302);
+        expect(response.headers.location).toMatch(new RegExp(`^${urlDestination}`));
+      })
+      .catch(leveErreur);
+
+    it("redirige vers l'URL (FC+) de création de session", () => {
+      serveur.adaptateurFranceConnectPlus().urlCreationSession = () => Promise.resolve(
+        `http://localhost:${port}/redirectionConnexion`, // page inexistante, résultera en une erreur HTTP 404
+      );
+
+      return verifieRedirection(`http://localhost:${port}/auth/fcplus/creationSession`, `http://localhost:${port}/redirectionConnexion`);
     });
   });
 });

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -39,8 +39,10 @@ const serveurTest = () => {
     adaptateurEnvironnement = {
       avecEnvoiCookieSurHTTP: () => true,
       avecRequetePieceJustificative: () => true,
+      identifiantClient: () => '',
       identifiantEIDAS: () => 'FR/BE/123456789',
       secretJetonSession: () => 'secret',
+      urlRedirectionConnexion: () => '',
       urlRedirectionDeconnexion: () => '',
     };
 
@@ -48,6 +50,7 @@ const serveurTest = () => {
       recupereDonneesJetonAcces: () => Promise.resolve({}),
       recupereInfosUtilisateurChiffrees: () => Promise.resolve(),
       recupereURLClefsPubliques: () => Promise.resolve(),
+      urlCreationSession: () => Promise.resolve(''),
       urlDestructionSession: () => Promise.resolve(''),
     };
 

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -39,6 +39,7 @@ const serveurTest = () => {
     adaptateurEnvironnement = {
       avecEnvoiCookieSurHTTP: () => true,
       avecRequetePieceJustificative: () => true,
+      fournisseurIdentiteSuggere: () => '',
       identifiantClient: () => '',
       identifiantEIDAS: () => 'FR/BE/123456789',
       secretJetonSession: () => 'secret',


### PR DESCRIPTION
Pour plus tard…
- regarder s'il ne faut pas ajouter des `return` dans les tests de `test/api/destructionSessionFCPlus.spec.js`
- factoriser adaptateurChiffrement.clefHachage(`${Math.random()}`)