### PR TITLE
Ajout route `GET /ebms/messages/reponseJustificatif`

### DIFF
--- a/src/routes/routesEbms.js
+++ b/src/routes/routesEbms.js
@@ -2,9 +2,10 @@ const express = require('express');
 
 const EnteteErreur = require('../ebms/enteteErreur');
 const EnteteRequete = require('../ebms/enteteRequete');
-const ReponseErreur = require('../ebms/reponseErreur');
-const RequeteJustificatif = require('../ebms/requeteJustificatif');
 const PointAcces = require('../ebms/pointAcces');
+const ReponseErreur = require('../ebms/reponseErreur');
+const ReponseVerificationSysteme = require('../ebms/reponseVerificationSysteme');
+const RequeteJustificatif = require('../ebms/requeteJustificatif');
 
 const routesEbms = (config) => {
   const { adaptateurUUID, horodateur } = config;
@@ -59,6 +60,16 @@ const routesEbms = (config) => {
     });
     reponse.set('Content-Type', 'text/xml');
     reponse.send(reponseErreur.corpsMessageEnXML());
+  });
+
+  routes.get('/messages/reponseJustificatif', (requete, reponse) => {
+    const reponseJustificatif = new ReponseVerificationSysteme({ adaptateurUUID, horodateur }, {
+      destinataire: new PointAcces('unTypeIdentifiant', 'unIdentifiant'),
+      idRequete: '12345678-1234-1234-1234-1234567890ab',
+      idConversation: '12345',
+    });
+    reponse.set('Content-Type', 'text/xml');
+    reponse.send(reponseJustificatif.corpsMessageEnXML());
   });
 
   return routes;

--- a/test/routes/routesEbms.spec.js
+++ b/test/routes/routesEbms.spec.js
@@ -62,4 +62,12 @@ describe('Le serveur des routes `/ebms`', () => {
       })
       .catch(leveErreur));
   });
+
+  describe('sur GET /ebms/messages/reponseJustificatif', () => {
+    it('sert une réponse au format XML', () => axios.get(`http://localhost:${port}/ebms/messages/reponseJustificatif`)
+      .then((reponse) => {
+        expect(reponse.headers['content-type']).toEqual('text/xml; charset=utf-8');
+      })
+      .catch(leveErreur));
+  });
 });


### PR DESCRIPTION
En exposant cette route, on peut utiliser le validateur fourni par la Commission Européenne

(https://oots-testing-pr-ag.westeurope.cloudapp.azure.com/ootsvalidator/request_response/upload)