### PR TITLE
Rends message de réponse conforme aux règles de validation

### DIFF
--- a/src/ebms/reponseVerificationSysteme.js
+++ b/src/ebms/reponseVerificationSysteme.js
@@ -23,6 +23,7 @@ class ReponseVerificationSysteme extends Message {
     return `<query:QueryResponse
         xmlns:query="urn:oasis:names:tc:ebxml-regrep:xsd:query:4.0"
         xmlns:rim="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0"
+        xmlns:sdg="http://data.europa.eu/p4s"
         xmlns:xlink="http://www.w3.org/1999/xlink"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"
@@ -46,15 +47,57 @@ class ReponseVerificationSysteme extends Message {
     </rim:SlotValue>
   </rim:Slot>
 
-  <rim:Slot name="EvidenceProvider"><!-- … --></rim:Slot>
-  <rim:Slot name="EvidenceRequester"><!-- … --></rim:Slot>
+  <rim:Slot name="EvidenceProvider">
+    <rim:SlotValue xsi:type="rim:CollectionValueType">
+      <rim:Element xsi:type="rim:AnyValueType">
+        <sdg:Agent>
+          <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR"></sdg:Identifier>
+          <sdg:Name></sdg:Name>
+          <sdg:Classification>EP</sdg:Classification>
+        </sdg:Agent>
+      </rim:Element>
+    </rim:SlotValue>
+  </rim:Slot>
+
+  <rim:Slot name="EvidenceRequester">
+    <rim:SlotValue xsi:type="rim:AnyValueType">
+      <sdg:Agent>
+        <sdg:Identifier schemeID="urn:cef.eu:names:identifier:EAS:0096"></sdg:Identifier>
+        <sdg:Name></sdg:Name>
+      </sdg:Agent>
+    </rim:SlotValue>
+  </rim:Slot>
 
   <rim:RegistryObjectList>
     <rim:RegistryObject xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="rim:ExtrinsicObjectType" id="urn:uuid:0c37ed98-5774-407a-a056-21eeffe66712">
       <rim:Slot name="EvidenceMetadata">
-        <sdg:Distribution>
-          <sdg:Format>application/pdf</sdg:Format>
-        </sdg:Distribution>
+        <rim:SlotValue xsi:type="rim:AnyValueType">
+          <sdg:Evidence>
+            <sdg:Identifier>${this.adaptateurUUID?.genereUUID()}</sdg:Identifier>
+            <sdg:IsAbout>
+              <sdg:NaturalPerson>
+                <sdg:Identifier schemeID='eidas'>DK/DE/123123123</sdg:Identifier>
+                <sdg:FamilyName></sdg:FamilyName>
+                <sdg:GivenName></sdg:GivenName>
+                <sdg:DateOfBirth>1970-03-01</sdg:DateOfBirth>
+              </sdg:NaturalPerson>
+            </sdg:IsAbout>
+            <sdg:IssuingAuthority>
+              <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR"></sdg:Identifier>
+              <sdg:Name></sdg:Name>
+            </sdg:IssuingAuthority>
+            <sdg:IsConformantTo>
+              <sdg:EvidenceTypeClassification>
+                https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/FR/12345678-1234-1234-1234-1234567890ab
+              </sdg:EvidenceTypeClassification>
+              <sdg:Title lang="EN"></sdg:Title>
+            </sdg:IsConformantTo>
+            <sdg:IssuingDate>1970-03-03</sdg:IssuingDate>
+            <sdg:Distribution>
+              <sdg:Format>application/pdf</sdg:Format>
+            </sdg:Distribution>
+          </sdg:Evidence>
+        </rim:SlotValue>
       </rim:Slot>
       <rim:RepositoryItemRef xlink:href="${this.pieceJointe.identifiant}" xlink:title="Evidence"/>
     </rim:RegistryObject>

--- a/test/ebms/reponseVerificationSysteme.spec.js
+++ b/test/ebms/reponseVerificationSysteme.spec.js
@@ -1,3 +1,4 @@
+const { parseXML, valeurSlot, verifiePresenceSlot } = require('./utils');
 const ReponseVerificationSysteme = require('../../src/ebms/reponseVerificationSysteme');
 const PointAcces = require('../../src/ebms/pointAcces');
 
@@ -10,6 +11,75 @@ describe('Reponse Verification Systeme', () => {
   beforeEach(() => {
     adaptateurUUID.genereUUID = () => '';
     horodateur.maintenant = () => '';
+  });
+
+  it('contient la description des méta-données de la pièce justificative', () => {
+    const reponse = new ReponseVerificationSysteme(config, donnees);
+    const xml = parseXML(reponse.corpsMessageEnXML());
+
+    const scopeRecherche = xml.QueryResponse.RegistryObjectList.RegistryObject;
+    verifiePresenceSlot('EvidenceMetadata', scopeRecherche);
+
+    const evidence = valeurSlot('EvidenceMetadata', scopeRecherche).Evidence;
+    expect(evidence).toBeDefined();
+    expect(evidence.Identifier).toBeDefined();
+    expect(evidence.IsAbout).toBeDefined();
+    expect(evidence.IsAbout.NaturalPerson).toBeDefined();
+    expect(evidence.IsAbout.NaturalPerson.Identifier).toBeDefined(); // /!\
+    expect(evidence.IsAbout.NaturalPerson.Identifier['@_schemeID']).toBe('eidas');
+    expect(evidence.IsAbout.NaturalPerson.FamilyName).toBeDefined();
+    expect(evidence.IsAbout.NaturalPerson.GivenName).toBeDefined();
+    expect(evidence.IsAbout.NaturalPerson.DateOfBirth).toBeDefined();
+    expect(evidence.IssuingAuthority).toBeDefined();
+    expect(evidence.IssuingAuthority.Identifier).toBeDefined(); // /!\
+    expect(evidence.IssuingAuthority.Identifier['@_schemeID']).toBe('urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR');
+    expect(evidence.IssuingAuthority.Name).toBeDefined();
+    expect(evidence.IsConformantTo).toBeDefined();
+    expect(evidence.IsConformantTo.EvidenceTypeClassification).toBeDefined();
+    expect(evidence.IsConformantTo.Title).toBeDefined();
+    expect(evidence.IsConformantTo.Title['@_lang']).toBe('EN');
+    expect(evidence.IssuingDate).toBeDefined();
+    expect(evidence.Distribution).toBeDefined();
+  });
+
+  it("contient la description d'un fournisseur de pièces justificatives", () => {
+    const reponse = new ReponseVerificationSysteme(config, donnees);
+    const xml = parseXML(reponse.corpsMessageEnXML());
+
+    const scopeRecherche = xml.QueryResponse;
+    verifiePresenceSlot('EvidenceProvider', scopeRecherche);
+
+    const fournisseur = valeurSlot('EvidenceProvider', scopeRecherche).Agent;
+    expect(fournisseur).toBeDefined();
+    expect(fournisseur.Identifier).toBeDefined();
+    expect(fournisseur.Identifier['@_schemeID']).toBe('urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR');
+    expect(fournisseur.Name).toBeDefined();
+    expect(fournisseur.Classification).toBeDefined();
+    expect(fournisseur.Classification).toBe('EP');
+  });
+
+  it('contient la description du requêteur de la pièce justificative', () => {
+    const reponse = new ReponseVerificationSysteme(config, donnees);
+    const xml = parseXML(reponse.corpsMessageEnXML());
+
+    const scopeRecherche = xml.QueryResponse;
+    verifiePresenceSlot('EvidenceRequester', scopeRecherche);
+
+    const requeteur = valeurSlot('EvidenceRequester', scopeRecherche).Agent;
+    expect(requeteur).toBeDefined();
+    expect(requeteur.Identifier).toBeDefined();
+    expect(requeteur.Identifier['@_schemeID']).toBeDefined(); // /!\
+    expect(requeteur.Name).toBeDefined();
+  });
+
+  it('injecte un identifiant unique de pièce justificative', () => {
+    adaptateurUUID.genereUUID = () => '11111111-1111-1111-1111-111111111111';
+    const reponse = new ReponseVerificationSysteme(config, donnees);
+    const xml = parseXML(reponse.corpsMessageEnXML());
+    const scopeRecherche = xml.QueryResponse.RegistryObjectList.RegistryObject;
+
+    const idPiece = valeurSlot('EvidenceMetadata', scopeRecherche).Evidence.Identifier;
+    expect(idPiece).toEqual('11111111-1111-1111-1111-111111111111');
   });
 
   it('contient une pièce jointe', () => {

--- a/test/ebms/utils.js
+++ b/test/ebms/utils.js
@@ -19,7 +19,12 @@ const valeurSlot = (nomSlot, scopeRecherche) => {
   const sectionSlots = scopeRecherche.Slot;
   const slots = [].concat(sectionSlots);
   const slot = slots.find((s) => s['@_name'] === nomSlot).SlotValue;
-  return (slot['@_type'] === 'rim:AnyValueType') ? slot : slot.Value;
+
+  switch (slot['@_type']) {
+    case 'rim:AnyValueType': return slot;
+    case 'rim:CollectionValueType': return slot.Element;
+    default: return slot.Value;
+  }
 };
 
 module.exports = { parseXML, verifiePresenceSlot, valeurSlot };


### PR DESCRIPTION
Reste à faire :
- Injecter les bonnes infos de l'utilisateur faisant la requête
- Injecter les bonnes infos de la structure qui requête la pièce justificative (C1)
- Injecter le bon identifiant du fournisseur de pièce justificative (en lien avec ce qui est déclaré dans les Common Services ?)
- Nettoyage : extraire objet `Personne` (et peut-être objets `Fournisseur` et `Requêteur`)