### PR TITLE
Injecte l'identifiant de type de justificatif dans la requête

### DIFF
--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -23,7 +23,12 @@ const pieceJustificative = (
   reponse,
 ) => {
   const idConversation = adaptateurUUID.genereUUID();
-  const { codeDemarche, nomDestinataire, previsualisationRequise } = requete.query;
+  const {
+    codeDemarche,
+    idTypeJustificatif,
+    nomDestinataire,
+    previsualisationRequise,
+  } = requete.query;
 
   return depotPointsAcces.trouvePointAcces(nomDestinataire)
     .then((destinataire) => adaptateurDomibus.envoieMessageRequete({
@@ -31,6 +36,7 @@ const pieceJustificative = (
       destinataire,
       idConversation,
       identifiantEIDAS: adaptateurEnvironnement.identifiantEIDAS(),
+      idTypeJustificatif,
       previsualisationRequise: (previsualisationRequise === 'true' || previsualisationRequise === ''),
     }))
     .then(() => Promise.any([

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -11,6 +11,7 @@ class RequeteJustificatif extends Message {
       destinataire = {},
       idConversation = config.adaptateurUUID.genereUUID(),
       identifiantEIDAS = 'DK/DE/123123123',
+      idTypeJustificatif = 'https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/b6a49e54-8b3c-4688-acad-380440dc5962',
       previsualisationRequise = false,
     } = {},
   ) {
@@ -18,6 +19,7 @@ class RequeteJustificatif extends Message {
 
     this.codeDemarche = codeDemarche;
     this.identifiantEIDAS = identifiantEIDAS;
+    this.idTypeJustificatif = idTypeJustificatif;
     this.previsualisationRequise = previsualisationRequise;
   }
 
@@ -143,7 +145,7 @@ class RequeteJustificatif extends Message {
       <rim:SlotValue xsi:type="rim:AnyValueType">
         <sdg:DataServiceEvidenceType xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0">
           <sdg:Identifier>a8851d44-8f62-4561-99d2-5383ce3f30a7</sdg:Identifier>
-          <sdg:EvidenceTypeClassification>https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/b6a49e54-8b3c-4688-acad-380440dc5962</sdg:EvidenceTypeClassification>
+          <sdg:EvidenceTypeClassification>${this.idTypeJustificatif}</sdg:EvidenceTypeClassification>
           <sdg:Title lang="EN">Diploma</sdg:Title>
           <sdg:DistributedAs>
             <sdg:Format>application/xml</sdg:Format>

--- a/test/api/pieceJustificative.spec.js
+++ b/test/api/pieceJustificative.spec.js
@@ -52,12 +52,27 @@ describe('Le requêteur de pièce justificative', () => {
     return pieceJustificative(config, requete, reponse);
   });
 
-  it('transmets le code démarche dans la requête', () => {
+  it('transmet le code démarche dans la requête', () => {
     requete.query.codeDemarche = 'UN_CODE';
 
     adaptateurDomibus.envoieMessageRequete = ({ codeDemarche }) => {
       try {
         expect(codeDemarche).toEqual('UN_CODE');
+        return Promise.resolve();
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return pieceJustificative(config, requete, reponse);
+  });
+
+  it("transmet l'identifiant de type de pièce justificative demandée", () => {
+    requete.query.idTypeJustificatif = 'unIdentifiant';
+
+    adaptateurDomibus.envoieMessageRequete = ({ idTypeJustificatif }) => {
+      try {
+        expect(idTypeJustificatif).toEqual('unIdentifiant');
         return Promise.resolve();
       } catch (e) {
         return Promise.reject(e);

--- a/test/ebms/requeteJustificatif.spec.js
+++ b/test/ebms/requeteJustificatif.spec.js
@@ -75,4 +75,15 @@ describe("La vue du message de requête d'un justificatif", () => {
     const personne = valeurSlot('NaturalPerson', xml.QueryRequest.Query);
     expect(personne.Person.Identifier['#text']).toBe('BE/FR/123456789');
   });
+
+  it("injecte l'identifiant de type de justificatif demandé", () => {
+    const requeteJustificatif = new RequeteJustificatif(
+      configurationRequete,
+      { idTypeJustificatif: 'unIdentifiant' },
+    );
+    const xml = parseXML(requeteJustificatif.corpsMessageEnXML());
+
+    const requete = valeurSlot('EvidenceRequest', xml.QueryRequest.Query);
+    expect(requete.DataServiceEvidenceType.EvidenceTypeClassification).toBe('unIdentifiant');
+  });
 });


### PR DESCRIPTION
… En vue de pouvoir tester avec d'autres États Membres.

(De fait, ce n'est pas génial et on va rapidement vouloir passer par un adaptateur de Services Communs qui va fournir ces informations.)