### PR TITLE
Introduction objet métier `TypeJustificatif`

### DIFF
--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -1,4 +1,5 @@
 const { ErreurAbsenceReponseDestinataire, ErreurReponseRequete, ErreurDestinataireInexistant } = require('../erreurs');
+const TypeJustificatif = require('../ebms/typeJustificatif');
 
 const urlRedirection = (idConversation, adaptateurDomibus) => adaptateurDomibus
   .urlRedirectionDepuisReponse(idConversation)
@@ -29,6 +30,7 @@ const pieceJustificative = (
     nomDestinataire,
     previsualisationRequise,
   } = requete.query;
+  const typeJustificatif = new TypeJustificatif({ id: idTypeJustificatif });
 
   return depotPointsAcces.trouvePointAcces(nomDestinataire)
     .then((destinataire) => adaptateurDomibus.envoieMessageRequete({
@@ -36,7 +38,7 @@ const pieceJustificative = (
       destinataire,
       idConversation,
       identifiantEIDAS: adaptateurEnvironnement.identifiantEIDAS(),
-      idTypeJustificatif,
+      typeJustificatif,
       previsualisationRequise: (previsualisationRequise === 'true' || previsualisationRequise === ''),
     }))
     .then(() => Promise.any([

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -1,5 +1,6 @@
 const EnteteRequete = require('./enteteRequete');
 const Message = require('./message');
+const TypeJustificatif = require('./typeJustificatif');
 
 class RequeteJustificatif extends Message {
   static ClasseEntete = EnteteRequete;
@@ -11,7 +12,7 @@ class RequeteJustificatif extends Message {
       destinataire = {},
       idConversation = config.adaptateurUUID.genereUUID(),
       identifiantEIDAS = 'DK/DE/123123123',
-      idTypeJustificatif = 'https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/b6a49e54-8b3c-4688-acad-380440dc5962',
+      typeJustificatif = new TypeJustificatif('https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/b6a49e54-8b3c-4688-acad-380440dc5962'),
       previsualisationRequise = false,
     } = {},
   ) {
@@ -19,7 +20,7 @@ class RequeteJustificatif extends Message {
 
     this.codeDemarche = codeDemarche;
     this.identifiantEIDAS = identifiantEIDAS;
-    this.idTypeJustificatif = idTypeJustificatif;
+    this.typeJustificatif = typeJustificatif;
     this.previsualisationRequise = previsualisationRequise;
   }
 
@@ -145,7 +146,7 @@ class RequeteJustificatif extends Message {
       <rim:SlotValue xsi:type="rim:AnyValueType">
         <sdg:DataServiceEvidenceType xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0">
           <sdg:Identifier>a8851d44-8f62-4561-99d2-5383ce3f30a7</sdg:Identifier>
-          <sdg:EvidenceTypeClassification>${this.idTypeJustificatif}</sdg:EvidenceTypeClassification>
+          <sdg:EvidenceTypeClassification>${this.typeJustificatif.id}</sdg:EvidenceTypeClassification>
           <sdg:Title lang="EN">Diploma</sdg:Title>
           <sdg:DistributedAs>
             <sdg:Format>application/xml</sdg:Format>

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -12,7 +12,7 @@ class RequeteJustificatif extends Message {
       destinataire = {},
       idConversation = config.adaptateurUUID.genereUUID(),
       identifiantEIDAS = 'DK/DE/123123123',
-      typeJustificatif = new TypeJustificatif('https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/b6a49e54-8b3c-4688-acad-380440dc5962'),
+      typeJustificatif = new TypeJustificatif({}),
       previsualisationRequise = false,
     } = {},
   ) {
@@ -142,18 +142,7 @@ class RequeteJustificatif extends Message {
         </sdg:Person>
       </rim:SlotValue>
     </rim:Slot>
-    <rim:Slot name="EvidenceRequest">
-      <rim:SlotValue xsi:type="rim:AnyValueType">
-        <sdg:DataServiceEvidenceType xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0">
-          <sdg:Identifier>a8851d44-8f62-4561-99d2-5383ce3f30a7</sdg:Identifier>
-          <sdg:EvidenceTypeClassification>${this.typeJustificatif.id}</sdg:EvidenceTypeClassification>
-          <sdg:Title lang="EN">Diploma</sdg:Title>
-          <sdg:DistributedAs>
-            <sdg:Format>application/xml</sdg:Format>
-          </sdg:DistributedAs>
-        </sdg:DataServiceEvidenceType>
-      </rim:SlotValue>
-    </rim:Slot>
+    ${this.typeJustificatif.enXML()}
   </query:Query>
 </query:QueryRequest>`;
   }

--- a/src/ebms/typeJustificatif.js
+++ b/src/ebms/typeJustificatif.js
@@ -1,0 +1,7 @@
+class TypeJustificatif {
+  constructor({ id }) {
+    this.id = id;
+  }
+}
+
+module.exports = TypeJustificatif;

--- a/src/ebms/typeJustificatif.js
+++ b/src/ebms/typeJustificatif.js
@@ -1,7 +1,32 @@
+const FORMATS_DISTRIBUTION = {
+  FORMAT_PDF: 'application/pdf',
+};
+
 class TypeJustificatif {
-  constructor({ id }) {
-    this.id = id;
+  constructor(donnees) {
+    const { id, descriptions, formatDistribution } = donnees;
+    this.id = id || 'https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/00000000-0000-0000-0000-000000000000';
+    this.descriptions = descriptions;
+    this.formatDistribution = formatDistribution || FORMATS_DISTRIBUTION.FORMAT_PDF;
+  }
+
+  enXML() {
+    return `
+<rim:Slot name="EvidenceRequest">
+  <rim:SlotValue xsi:type="rim:AnyValueType">
+    <sdg:DataServiceEvidenceType xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0">
+      <sdg:Identifier>00000000-0000-0000-0000-000000000000</sdg:Identifier>
+      <sdg:EvidenceTypeClassification>${this.id}</sdg:EvidenceTypeClassification>
+      <sdg:Title lang="EN">${this.descriptions?.EN}</sdg:Title>
+      <sdg:DistributedAs>
+        <sdg:Format>${this.formatDistribution}</sdg:Format>
+      </sdg:DistributedAs>
+    </sdg:DataServiceEvidenceType>
+  </rim:SlotValue>
+</rim:Slot>
+    `;
   }
 }
 
+Object.assign(TypeJustificatif, FORMATS_DISTRIBUTION);
 module.exports = TypeJustificatif;

--- a/test/api/pieceJustificative.spec.js
+++ b/test/api/pieceJustificative.spec.js
@@ -70,9 +70,9 @@ describe('Le requêteur de pièce justificative', () => {
   it("transmet l'identifiant de type de pièce justificative demandée", () => {
     requete.query.idTypeJustificatif = 'unIdentifiant';
 
-    adaptateurDomibus.envoieMessageRequete = ({ idTypeJustificatif }) => {
+    adaptateurDomibus.envoieMessageRequete = ({ typeJustificatif }) => {
       try {
-        expect(idTypeJustificatif).toEqual('unIdentifiant');
+        expect(typeJustificatif.id).toEqual('unIdentifiant');
         return Promise.resolve();
       } catch (e) {
         return Promise.reject(e);

--- a/test/ebms/requeteJustificatif.spec.js
+++ b/test/ebms/requeteJustificatif.spec.js
@@ -1,5 +1,6 @@
 const { parseXML, verifiePresenceSlot, valeurSlot } = require('./utils');
 const RequeteJustificatif = require('../../src/ebms/requeteJustificatif');
+const TypeJustificatif = require('../../src/ebms/typeJustificatif');
 
 describe("La vue du message de requête d'un justificatif", () => {
   const adaptateurUUID = {};
@@ -79,7 +80,7 @@ describe("La vue du message de requête d'un justificatif", () => {
   it("injecte l'identifiant de type de justificatif demandé", () => {
     const requeteJustificatif = new RequeteJustificatif(
       configurationRequete,
-      { idTypeJustificatif: 'unIdentifiant' },
+      { typeJustificatif: new TypeJustificatif({ id: 'unIdentifiant' }) },
     );
     const xml = parseXML(requeteJustificatif.corpsMessageEnXML());
 

--- a/test/ebms/typeJustificatif.spec.js
+++ b/test/ebms/typeJustificatif.spec.js
@@ -1,0 +1,26 @@
+const TypeJustificatif = require('../../src/ebms/typeJustificatif');
+
+describe('Le type de justificatif', () => {
+  it("s'affiche en XML", () => {
+    const typeJustificatif = new TypeJustificatif({
+      id: 'unIdentifiant',
+      descriptions: { EN: 'someType' },
+      formatDistribution: TypeJustificatif.FORMAT_PDF,
+    });
+
+    expect(typeJustificatif.enXML()).toBe(`
+<rim:Slot name="EvidenceRequest">
+  <rim:SlotValue xsi:type="rim:AnyValueType">
+    <sdg:DataServiceEvidenceType xmlns="urn:oasis:names:tc:ebxml-regrep:xsd:rim:4.0">
+      <sdg:Identifier>00000000-0000-0000-0000-000000000000</sdg:Identifier>
+      <sdg:EvidenceTypeClassification>unIdentifiant</sdg:EvidenceTypeClassification>
+      <sdg:Title lang="EN">someType</sdg:Title>
+      <sdg:DistributedAs>
+        <sdg:Format>application/pdf</sdg:Format>
+      </sdg:DistributedAs>
+    </sdg:DataServiceEvidenceType>
+  </rim:SlotValue>
+</rim:Slot>
+    `);
+  });
+});


### PR DESCRIPTION
Cette PR s'inscrit dans un mouvement plus large d'introduction d'appels aux services communs.

La feuille de route : 

- [ ] Extraire objet métier `TypeJustificatif` et lui déléguer la génération du XML correspondant (**PR en cours**)
- [ ] Introduire un « faux dépôt Services Communs » et l’interroger pour obtenir les informations du type de justificatif
- [ ] Utiliser le code démarche pour trouver les infos du type de justificatif dans le « faux dépôt »
- [ ] Extraire objet métier Fournisseur et lui déléguer la génération du XML correspondant
- [ ] Passer dans la requête un param idPays et en déduire du dépôt le fournisseur et le point accès associés.