### PR TITLE
Récupère infos fournisseurs depuis (faux) dépôt services communs

### DIFF
--- a/server.js
+++ b/server.js
@@ -5,9 +5,11 @@ const adaptateurEnvironnement = require('./src/adaptateurs/adaptateurEnvironneme
 const adaptateurUUID = require('./src/adaptateurs/adaptateurUUID');
 const horodateur = require('./src/adaptateurs/horodateur');
 const DepotPointsAcces = require('./src/depots/depotPointsAcces');
+const DepotServicesCommuns = require('./src/depots/depotServicesCommunsLocal');
 
 const adaptateurDomibus = AdaptateurDomibus({ adaptateurUUID, horodateur });
 const depotPointsAcces = new DepotPointsAcces(adaptateurDomibus);
+const depotServicesCommuns = new DepotServicesCommuns();
 const ecouteurDomibus = new EcouteurDomibus({ adaptateurDomibus, intervalleEcoute: 1000 });
 
 const serveur = OOTS_FRANCE.creeServeur({
@@ -15,6 +17,7 @@ const serveur = OOTS_FRANCE.creeServeur({
   adaptateurEnvironnement,
   adaptateurUUID,
   depotPointsAcces,
+  depotServicesCommuns,
   ecouteurDomibus,
   horodateur,
 });

--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -30,16 +30,17 @@ const pieceJustificative = (
     previsualisationRequise,
   } = requete.query;
 
-  return depotServicesCommuns.trouveTypeJustificatif(idTypeJustificatif)
-    .then((typeJustificatif) => depotPointsAcces
-      .trouvePointAcces(nomDestinataire)
-      .then((destinataire) => adaptateurDomibus.envoieMessageRequete({
-        codeDemarche,
-        destinataire,
-        idConversation,
-        typeJustificatif,
-        previsualisationRequise: (previsualisationRequise === 'true' || previsualisationRequise === ''),
-      })))
+  return Promise.all([
+    depotServicesCommuns.trouveTypeJustificatif(idTypeJustificatif),
+    depotPointsAcces.trouvePointAcces(nomDestinataire),
+  ])
+    .then(([typeJustificatif, destinataire]) => adaptateurDomibus.envoieMessageRequete({
+      codeDemarche,
+      destinataire,
+      idConversation,
+      typeJustificatif,
+      previsualisationRequise: (previsualisationRequise === 'true' || previsualisationRequise === ''),
+    }))
     .then(() => Promise.any([
       urlRedirection(idConversation, adaptateurDomibus),
       pieceJustificativeRecue(idConversation, adaptateurDomibus),

--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -1,5 +1,4 @@
 const { ErreurAbsenceReponseDestinataire, ErreurReponseRequete, ErreurDestinataireInexistant } = require('../erreurs');
-const TypeJustificatif = require('../ebms/typeJustificatif');
 
 const urlRedirection = (idConversation, adaptateurDomibus) => adaptateurDomibus
   .urlRedirectionDepuisReponse(idConversation)
@@ -18,6 +17,7 @@ const pieceJustificative = (
     adaptateurDomibus,
     adaptateurUUID,
     depotPointsAcces,
+    depotServicesCommuns,
   },
   requete,
   reponse,
@@ -29,16 +29,17 @@ const pieceJustificative = (
     nomDestinataire,
     previsualisationRequise,
   } = requete.query;
-  const typeJustificatif = new TypeJustificatif({ id: idTypeJustificatif });
 
-  return depotPointsAcces.trouvePointAcces(nomDestinataire)
-    .then((destinataire) => adaptateurDomibus.envoieMessageRequete({
-      codeDemarche,
-      destinataire,
-      idConversation,
-      typeJustificatif,
-      previsualisationRequise: (previsualisationRequise === 'true' || previsualisationRequise === ''),
-    }))
+  return depotServicesCommuns.trouveTypeJustificatif(idTypeJustificatif)
+    .then((typeJustificatif) => depotPointsAcces
+      .trouvePointAcces(nomDestinataire)
+      .then((destinataire) => adaptateurDomibus.envoieMessageRequete({
+        codeDemarche,
+        destinataire,
+        idConversation,
+        typeJustificatif,
+        previsualisationRequise: (previsualisationRequise === 'true' || previsualisationRequise === ''),
+      })))
     .then(() => Promise.any([
       urlRedirection(idConversation, adaptateurDomibus),
       pieceJustificativeRecue(idConversation, adaptateurDomibus),

--- a/src/api/pieceJustificative.js
+++ b/src/api/pieceJustificative.js
@@ -1,4 +1,9 @@
-const { ErreurAbsenceReponseDestinataire, ErreurReponseRequete, ErreurDestinataireInexistant } = require('../erreurs');
+const {
+  ErreurAbsenceReponseDestinataire,
+  ErreurDestinataireInexistant,
+  ErreurReponseRequete,
+  ErreurTypeJustificatifIntrouvable,
+} = require('../erreurs');
 
 const urlRedirection = (idConversation, adaptateurDomibus) => adaptateurDomibus
   .urlRedirectionDepuisReponse(idConversation)
@@ -54,7 +59,9 @@ const pieceJustificative = (
       }
     })
     .catch((e) => {
-      if (e instanceof ErreurDestinataireInexistant) {
+      if (
+        e instanceof ErreurDestinataireInexistant || e instanceof ErreurTypeJustificatifIntrouvable
+      ) {
         reponse.status(422).json({ erreur: e.message });
       } else if (e instanceof AggregateError) {
         let codeStatus = 500;

--- a/src/depots/depotServicesCommunsLocal.js
+++ b/src/depots/depotServicesCommunsLocal.js
@@ -1,0 +1,23 @@
+const TypeJustificatif = require('../ebms/typeJustificatif');
+
+const DONNEES_DEPOT = {
+  typesJustificatif: [{
+    id: '12345',
+    descriptions: { EN: 'someDummyType' },
+    formatDistribution: 'application/pdf',
+  }],
+};
+
+class DepotServicesCommunsLocal {
+  constructor(donnees = DONNEES_DEPOT) {
+    this.donnees = donnees;
+  }
+
+  trouveTypeJustificatif(id) {
+    const donneesTypeJustificatif = this.donnees.typesJustificatif.find((tj) => tj.id === id);
+    const typeJustificatif = new TypeJustificatif(donneesTypeJustificatif);
+    return Promise.resolve(typeJustificatif);
+  }
+}
+
+module.exports = DepotServicesCommunsLocal;

--- a/src/depots/depotServicesCommunsLocal.js
+++ b/src/depots/depotServicesCommunsLocal.js
@@ -1,3 +1,4 @@
+const { ErreurTypeJustificatifIntrouvable } = require('../erreurs');
 const TypeJustificatif = require('../ebms/typeJustificatif');
 
 const DONNEES_DEPOT = {
@@ -14,7 +15,11 @@ class DepotServicesCommunsLocal {
   }
 
   trouveTypeJustificatif(id) {
-    const donneesTypeJustificatif = this.donnees.typesJustificatif.find((tj) => tj.id === id);
+    const donneesTypeJustificatif = this.donnees?.typesJustificatif?.find((tj) => tj.id === id);
+    if (typeof donneesTypeJustificatif === 'undefined') {
+      return Promise.reject(new ErreurTypeJustificatifIntrouvable(`Type justificatif avec identifiant "${id}" introuvable`));
+    }
+
     const typeJustificatif = new TypeJustificatif(donneesTypeJustificatif);
     return Promise.resolve(typeJustificatif);
   }

--- a/src/ebms/typeJustificatif.js
+++ b/src/ebms/typeJustificatif.js
@@ -3,7 +3,7 @@ const FORMATS_DISTRIBUTION = {
 };
 
 class TypeJustificatif {
-  constructor(donnees) {
+  constructor(donnees = {}) {
     const { id, descriptions, formatDistribution } = donnees;
     this.id = id || 'https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/00000000-0000-0000-0000-000000000000';
     this.descriptions = descriptions;

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -5,6 +5,7 @@ class ErreurEchecAuthentification extends Error {}
 class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurJetonInvalide extends Error {}
 class ErreurReponseRequete extends Error {}
+class ErreurTypeJustificatifIntrouvable extends Error {}
 
 module.exports = {
   ErreurAbsenceReponseDestinataire,
@@ -14,4 +15,5 @@ module.exports = {
   ErreurInstructionSOAPInconnue,
   ErreurJetonInvalide,
   ErreurReponseRequete,
+  ErreurTypeJustificatifIntrouvable,
 };

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -12,6 +12,7 @@ const creeServeur = (config) => {
     adaptateurEnvironnement,
     adaptateurUUID,
     depotPointsAcces,
+    depotServicesCommuns,
     ecouteurDomibus,
     horodateur,
   } = config;
@@ -33,6 +34,7 @@ const creeServeur = (config) => {
     adaptateurEnvironnement,
     adaptateurUUID,
     depotPointsAcces,
+    depotServicesCommuns,
   }));
 
   app.use('/', routesBase());

--- a/src/routes/routesRequete.js
+++ b/src/routes/routesRequete.js
@@ -8,6 +8,7 @@ const routesRequete = (config) => {
     adaptateurEnvironnement,
     adaptateurUUID,
     depotPointsAcces,
+    depotServicesCommuns,
   } = config;
 
   const routes = express.Router();
@@ -19,6 +20,7 @@ const routesRequete = (config) => {
           adaptateurDomibus,
           adaptateurUUID,
           depotPointsAcces,
+          depotServicesCommuns,
         },
         requete,
         reponse,

--- a/test/api/pieceJustificative.spec.js
+++ b/test/api/pieceJustificative.spec.js
@@ -12,11 +12,14 @@ describe('Le requêteur de pièce justificative', () => {
   const adaptateurEnvironnement = {};
   const adaptateurUUID = {};
   const depotPointsAcces = {};
+  const depotServicesCommuns = {};
+
   const config = {
     adaptateurDomibus,
     adaptateurEnvironnement,
     adaptateurUUID,
     depotPointsAcces,
+    depotServicesCommuns,
   };
   const requete = {};
   const reponse = {};
@@ -27,6 +30,7 @@ describe('Le requêteur de pièce justificative', () => {
     adaptateurDomibus.urlRedirectionDepuisReponse = () => Promise.resolve();
     adaptateurUUID.genereUUID = () => '';
     depotPointsAcces.trouvePointAcces = () => Promise.resolve({});
+    depotServicesCommuns.trouveTypeJustificatif = () => Promise.resolve({});
 
     requete.query = {};
     reponse.json = () => Promise.resolve();
@@ -66,8 +70,24 @@ describe('Le requêteur de pièce justificative', () => {
     return pieceJustificative(config, requete, reponse);
   });
 
-  it("transmet l'identifiant de type de pièce justificative demandée", () => {
+  it('interroge dépôt services communs pour récupérer infos relatives au type de justificatif', () => {
+    expect.assertions(1);
     requete.query.idTypeJustificatif = 'unIdentifiant';
+
+    depotServicesCommuns.trouveTypeJustificatif = (id) => {
+      try {
+        expect(id).toBe('unIdentifiant');
+        return Promise.resolve({});
+      } catch (e) {
+        return Promise.reject(e);
+      }
+    };
+
+    return pieceJustificative(config, requete, reponse);
+  });
+
+  it("transmet l'identifiant de type de pièce justificative demandée", () => {
+    depotServicesCommuns.trouveTypeJustificatif = () => Promise.resolve({ id: 'unIdentifiant' });
 
     adaptateurDomibus.envoieMessageRequete = ({ typeJustificatif }) => {
       try {

--- a/test/depots/depotServicesCommunsLocal.spec.js
+++ b/test/depots/depotServicesCommunsLocal.spec.js
@@ -1,0 +1,20 @@
+const DepotServicesCommuns = require('../../src/depots/depotServicesCommunsLocal');
+
+describe('Le Dépôt (local, bouchonné) de données des services communs', () => {
+  it('trouve un type de justificatif à partir de son identifiant', () => {
+    const depot = new DepotServicesCommuns({
+      typesJustificatif: [{
+        id: '12345',
+        descriptions: { EN: 'someType' },
+        formatDistribution: 'application/pdf',
+      }],
+    });
+
+    return depot.trouveTypeJustificatif('12345')
+      .then((typeJustificatif) => {
+        expect(typeJustificatif.id).toBe('12345');
+        expect(typeJustificatif.descriptions).toEqual({ EN: 'someType' });
+        expect(typeJustificatif.formatDistribution).toBe('application/pdf');
+      });
+  });
+});

--- a/test/depots/depotServicesCommunsLocal.spec.js
+++ b/test/depots/depotServicesCommunsLocal.spec.js
@@ -1,3 +1,4 @@
+const { ErreurTypeJustificatifIntrouvable } = require('../../src/erreurs');
 const DepotServicesCommuns = require('../../src/depots/depotServicesCommunsLocal');
 
 describe('Le Dépôt (local, bouchonné) de données des services communs', () => {
@@ -15,6 +16,18 @@ describe('Le Dépôt (local, bouchonné) de données des services communs', () =
         expect(typeJustificatif.id).toBe('12345');
         expect(typeJustificatif.descriptions).toEqual({ EN: 'someType' });
         expect(typeJustificatif.formatDistribution).toBe('application/pdf');
+      });
+  });
+
+  it('retourne une erreur si type justificatif introuvable', () => {
+    expect.assertions(2);
+
+    const depot = new DepotServicesCommuns({});
+
+    return depot.trouveTypeJustificatif('12345')
+      .catch((e) => {
+        expect(e).toBeInstanceOf(ErreurTypeJustificatifIntrouvable);
+        expect(e.message).toBe('Type justificatif avec identifiant "12345" introuvable');
       });
   });
 });

--- a/test/routes/routesRequete.spec.js
+++ b/test/routes/routesRequete.spec.js
@@ -22,6 +22,7 @@ describe('Le serveur des routes `/requete`', () => {
         serveur.adaptateurDomibus().pieceJustificativeDepuisReponse = (
           () => Promise.reject(new ErreurAbsenceReponseDestinataire('aucune pièce reçue'))
         );
+
         return axios.get(`http://localhost:${port}/requete/pieceJustificative?destinataire=DESTINATAIRE_SILENCIEUX`)
           .catch(({ response }) => {
             expect(response.status).toEqual(504);

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -6,6 +6,7 @@ const serveurTest = () => {
   let adaptateurEnvironnement;
   let adaptateurUUID;
   let depotPointsAcces;
+  let depotServicesCommuns;
   let ecouteurDomibus;
   let horodateur;
 
@@ -34,6 +35,10 @@ const serveurTest = () => {
       trouvePointAcces: () => Promise.resolve({}),
     };
 
+    depotServicesCommuns = {
+      trouveTypeJustificatif: () => Promise.resolve({}),
+    };
+
     ecouteurDomibus = {
       arreteEcoute: () => {},
       ecoute: () => {},
@@ -49,6 +54,7 @@ const serveurTest = () => {
       adaptateurEnvironnement,
       adaptateurUUID,
       depotPointsAcces,
+      depotServicesCommuns,
       ecouteurDomibus,
       horodateur,
     });
@@ -64,6 +70,7 @@ const serveurTest = () => {
     adaptateurUUID: () => adaptateurUUID,
     arrete,
     depotPointsAcces: () => depotPointsAcces,
+    depotServicesCommuns: () => depotServicesCommuns,
     ecouteurDomibus: () => ecouteurDomibus,
     horodateur: () => horodateur,
     initialise,


### PR DESCRIPTION
… Les services communs étant actuellement bouchonnés.

Cette PR s'inscrit dans un mouvement plus large d'introduction d'appels aux services communs.

La feuille de route : 

- [x] Extraire objet métier `TypeJustificatif` et lui déléguer la génération du XML correspondant (cf. #7)
- [ ] Introduire un « faux dépôt Services Communs » et l’interroger pour obtenir les informations du type de justificatif (**PR en cours**)
- [ ] Utiliser le code démarche pour trouver les infos du type de justificatif dans le « faux dépôt »
- [ ] Extraire objet métier Fournisseur et lui déléguer la génération du XML correspondant
- [ ] Passer dans la requête un param idPays et en déduire du dépôt le fournisseur et le point accès associés.