### PR TITLE
Trouve le type justificatif depuis le code démarche

### DIFF
--- a/src/depots/depotServicesCommunsLocal.js
+++ b/src/depots/depotServicesCommunsLocal.js
@@ -1,10 +1,15 @@
-const { ErreurTypeJustificatifIntrouvable } = require('../erreurs');
+const { ErreurCodeDemarcheIntrouvable, ErreurTypeJustificatifIntrouvable } = require('../erreurs');
 const TypeJustificatif = require('../ebms/typeJustificatif');
 
 const DONNEES_DEPOT = {
+  demarches: [{
+    code: '00',
+    idsTypeJustificatif: ['https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/00000000-0000-0000-0000-000000000000'],
+  }],
+
   typesJustificatif: [{
-    id: '12345',
-    descriptions: { EN: 'someDummyType' },
+    id: 'https://sr.oots.tech.ec.europa.eu/evidencetypeclassifications/oots/00000000-0000-0000-0000-000000000000',
+    descriptions: { EN: 'System Health Check' },
     formatDistribution: 'application/pdf',
   }],
 };
@@ -22,6 +27,20 @@ class DepotServicesCommunsLocal {
 
     const typeJustificatif = new TypeJustificatif(donneesTypeJustificatif);
     return Promise.resolve(typeJustificatif);
+  }
+
+  trouveTypesJustificatifsPourDemarche(code) {
+    const typesJustificatifs = this.donnees
+      ?.demarches
+      ?.find((d) => d.code === code)
+      ?.idsTypeJustificatif
+      ?.map((id) => this.trouveTypeJustificatif(id));
+
+    if (typeof typesJustificatifs === 'undefined') {
+      return Promise.reject(new ErreurCodeDemarcheIntrouvable(`Code démarche "${code}" introuvable`));
+    }
+
+    return Promise.all(typesJustificatifs);
   }
 }
 

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -1,5 +1,6 @@
 class ErreurAbsenceReponseDestinataire extends Error {}
 class ErreurAucunMessageDomibusRecu extends Error {}
+class ErreurCodeDemarcheIntrouvable extends Error {}
 class ErreurDestinataireInexistant extends Error {}
 class ErreurEchecAuthentification extends Error {}
 class ErreurInstructionSOAPInconnue extends Error {}
@@ -10,6 +11,7 @@ class ErreurTypeJustificatifIntrouvable extends Error {}
 module.exports = {
   ErreurAbsenceReponseDestinataire,
   ErreurAucunMessageDomibusRecu,
+  ErreurCodeDemarcheIntrouvable,
   ErreurDestinataireInexistant,
   ErreurEchecAuthentification,
   ErreurInstructionSOAPInconnue,

--- a/test/api/pieceJustificative.spec.js
+++ b/test/api/pieceJustificative.spec.js
@@ -30,7 +30,7 @@ describe('Le requêteur de pièce justificative', () => {
     adaptateurDomibus.urlRedirectionDepuisReponse = () => Promise.resolve();
     adaptateurUUID.genereUUID = () => '';
     depotPointsAcces.trouvePointAcces = () => Promise.resolve({});
-    depotServicesCommuns.trouveTypeJustificatif = () => Promise.resolve({});
+    depotServicesCommuns.trouveTypesJustificatifsPourDemarche = () => Promise.resolve([]);
 
     requete.query = {};
     reponse.json = () => Promise.resolve();
@@ -70,14 +70,14 @@ describe('Le requêteur de pièce justificative', () => {
     return pieceJustificative(config, requete, reponse);
   });
 
-  it('interroge dépôt services communs pour récupérer infos relatives au type de justificatif', () => {
+  it('interroge dépôt services communs pour récupérer infos relatives au code démarche', () => {
     expect.assertions(1);
-    requete.query.idTypeJustificatif = 'unIdentifiant';
+    requete.query.codeDemarche = '00';
 
-    depotServicesCommuns.trouveTypeJustificatif = (id) => {
+    depotServicesCommuns.trouveTypesJustificatifsPourDemarche = (code) => {
       try {
-        expect(id).toBe('unIdentifiant');
-        return Promise.resolve({});
+        expect(code).toBe('00');
+        return Promise.resolve([]);
       } catch (e) {
         return Promise.reject(e);
       }
@@ -87,7 +87,7 @@ describe('Le requêteur de pièce justificative', () => {
   });
 
   it("transmet l'identifiant de type de pièce justificative demandée", () => {
-    depotServicesCommuns.trouveTypeJustificatif = () => Promise.resolve({ id: 'unIdentifiant' });
+    depotServicesCommuns.trouveTypesJustificatifsPourDemarche = () => Promise.resolve([{ id: 'unIdentifiant' }]);
 
     adaptateurDomibus.envoieMessageRequete = ({ typeJustificatif }) => {
       try {

--- a/test/constructeurs/constructeurDepotServicesCommuns.js
+++ b/test/constructeurs/constructeurDepotServicesCommuns.js
@@ -1,0 +1,41 @@
+const DepotServicesCommuns = require('../../src/depots/depotServicesCommunsLocal');
+
+class ConstructeurDepotServicesCommuns {
+  constructor() {
+    this.donnees = {};
+    this.compteur = 0;
+  }
+
+  avecTypeJustificatif(donnees) {
+    const donneesParDefaut = {
+      id: (this.compteur += 1),
+      descriptions: { EN: '' },
+      formatDistribution: 'application/xml',
+    };
+
+    this.donnees.typesJustificatif ||= [];
+    this.donnees.typesJustificatif.push(Object.assign(donneesParDefaut, donnees));
+    return this;
+  }
+
+  avecDemarche(code, descriptionsTypeJustificatif) {
+    const donneesDemarche = { code, idsTypeJustificatif: [] };
+    descriptionsTypeJustificatif.forEach((description) => {
+      const donneesTypeJustificatif = {};
+      this.compteur += 1;
+      donneesTypeJustificatif.id = this.compteur;
+      donneesTypeJustificatif.descriptions = { EN: description };
+      this.avecTypeJustificatif(donneesTypeJustificatif);
+      donneesDemarche.idsTypeJustificatif.push(donneesTypeJustificatif.id);
+    });
+    this.donnees.demarches ||= [];
+    this.donnees.demarches.push(donneesDemarche);
+    return this;
+  }
+
+  construis() {
+    return new DepotServicesCommuns(this.donnees);
+  }
+}
+
+module.exports = ConstructeurDepotServicesCommuns;

--- a/test/depots/depotServicesCommunsLocal.spec.js
+++ b/test/depots/depotServicesCommunsLocal.spec.js
@@ -1,15 +1,16 @@
-const { ErreurTypeJustificatifIntrouvable } = require('../../src/erreurs');
+const ConstructeurDepotServicesCommuns = require('../constructeurs/constructeurDepotServicesCommuns');
+const { ErreurCodeDemarcheIntrouvable, ErreurTypeJustificatifIntrouvable } = require('../../src/erreurs');
 const DepotServicesCommuns = require('../../src/depots/depotServicesCommunsLocal');
 
 describe('Le Dépôt (local, bouchonné) de données des services communs', () => {
   it('trouve un type de justificatif à partir de son identifiant', () => {
-    const depot = new DepotServicesCommuns({
-      typesJustificatif: [{
+    const depot = new ConstructeurDepotServicesCommuns()
+      .avecTypeJustificatif({
         id: '12345',
         descriptions: { EN: 'someType' },
         formatDistribution: 'application/pdf',
-      }],
-    });
+      })
+      .construis();
 
     return depot.trouveTypeJustificatif('12345')
       .then((typeJustificatif) => {
@@ -28,6 +29,33 @@ describe('Le Dépôt (local, bouchonné) de données des services communs', () =
       .catch((e) => {
         expect(e).toBeInstanceOf(ErreurTypeJustificatifIntrouvable);
         expect(e.message).toBe('Type justificatif avec identifiant "12345" introuvable');
+      });
+  });
+
+  it('trouve tous les types de justificatifs liés à un code démarche', () => {
+    const depot = new ConstructeurDepotServicesCommuns()
+      .avecDemarche('00', ['tj1', 'tj2'])
+      .construis();
+
+    return depot.trouveTypesJustificatifsPourDemarche('00')
+      .then((typesJustificatifs) => {
+        expect(typesJustificatifs.length).toBe(2);
+        expect(typesJustificatifs[0].descriptions.EN).toBe('tj1');
+        expect(typesJustificatifs[1].descriptions.EN).toBe('tj2');
+      });
+  });
+
+  it('retourne une erreur si code démarche introuvable', () => {
+    expect.assertions(2);
+
+    const depot = new ConstructeurDepotServicesCommuns()
+      .avecDemarche('00', [])
+      .construis();
+
+    return depot.trouveTypesJustificatifsPourDemarche('XX')
+      .catch((e) => {
+        expect(e).toBeInstanceOf(ErreurCodeDemarcheIntrouvable);
+        expect(e.message).toBe('Code démarche "XX" introuvable');
       });
   });
 });

--- a/test/routes/routesRequete.spec.js
+++ b/test/routes/routesRequete.spec.js
@@ -1,7 +1,11 @@
 const axios = require('axios');
 
 const serveurTest = require('./serveurTest');
-const { ErreurAbsenceReponseDestinataire, ErreurTypeJustificatifIntrouvable } = require('../../src/erreurs');
+const {
+  ErreurAbsenceReponseDestinataire,
+  ErreurCodeDemarcheIntrouvable,
+  ErreurTypeJustificatifIntrouvable,
+} = require('../../src/erreurs');
 
 describe('Le serveur des routes `/requete`', () => {
   const serveur = serveurTest();
@@ -35,6 +39,18 @@ describe('Le serveur des routes `/requete`', () => {
   it('retourne une erreur HTTP 422 (Unprocessable Content) si le type de justificatif est introuvable', () => {
     serveur.depotServicesCommuns().trouveTypeJustificatif = () => (
       Promise.reject(new ErreurTypeJustificatifIntrouvable('oups'))
+    );
+
+    return axios.get(`http://localhost:${port}/requete/pieceJustificative`)
+      .catch(({ response }) => {
+        expect(response.status).toEqual(422);
+        expect(response.data).toEqual({ erreur: 'oups' });
+      });
+  });
+
+  it('retourne une erreur HTTP 422 (Unprocessable Content) si le code démarche est introuvable', () => {
+    serveur.depotServicesCommuns().trouveTypesJustificatifsPourDemarche = () => (
+      Promise.reject(new ErreurCodeDemarcheIntrouvable('oups'))
     );
 
     return axios.get(`http://localhost:${port}/requete/pieceJustificative`)

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -37,6 +37,7 @@ const serveurTest = () => {
 
     depotServicesCommuns = {
       trouveTypeJustificatif: () => Promise.resolve({}),
+      trouveTypesJustificatifsPourDemarche: () => Promise.resolve([]),
     };
 
     ecouteurDomibus = {


### PR DESCRIPTION
<img width="1428" alt="Screenshot 2024-08-05 at 17 44 29" src="https://github.com/user-attachments/assets/adfb77e8-3e84-42b3-8448-1560ad7bfa08">

… Ce qui simplifie l'appel à `requete/pieceJustificative`, où le paramètre `idTypeJustificatif` n'est plus utile.