### PR TITLE
Script pour lire les logs Domibus

### DIFF
--- a/scripts/logsDomibus.sh
+++ b/scripts/logsDomibus.sh
@@ -1,0 +1,1 @@
+docker-compose exec domibus tail -f logs/catalina.out


### PR DESCRIPTION
… Sans avoir à journaliser depuis docker-compose. Cela permet en particulier de lire les logs au démarrage de Domibus et de vérifier quand il est effectivement démarré.