### PR TITLE
Annuaire requêteurs

### DIFF
--- a/src/depots/depotRequeteurs.js
+++ b/src/depots/depotRequeteurs.js
@@ -1,0 +1,22 @@
+const { ErreurRequeteurInexistant } = require('../erreurs');
+const Requeteur = require('../ebms/requeteur');
+
+class DepotRequeteurs {
+  constructor(donnees) {
+    this.donnees = donnees;
+  }
+
+  trouveRequeteur(id) {
+    const donneesRequeteur = this.donnees[id];
+    if (typeof donneesRequeteur === 'undefined') {
+      return Promise.reject(
+        new ErreurRequeteurInexistant(`Le requêteur avec comme identifiant "${id}" est inexistant`),
+      );
+    }
+
+    const resultat = new Requeteur({ id, ...donneesRequeteur });
+    return Promise.resolve(resultat);
+  }
+}
+
+module.exports = DepotRequeteurs;

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -1,6 +1,7 @@
 const EnteteRequete = require('./enteteRequete');
 const Fournisseur = require('./fournisseur');
 const Message = require('./message');
+const Requeteur = require('./requeteur');
 const TypeJustificatif = require('./typeJustificatif');
 
 class RequeteJustificatif extends Message {
@@ -13,6 +14,7 @@ class RequeteJustificatif extends Message {
       destinataire = {},
       fournisseur = new Fournisseur(),
       idConversation = config.adaptateurUUID.genereUUID(),
+      requeteur = new Requeteur(),
       typeJustificatif = new TypeJustificatif({}),
       previsualisationRequise = false,
     } = {},
@@ -21,6 +23,7 @@ class RequeteJustificatif extends Message {
 
     this.codeDemarche = codeDemarche;
     this.fournisseur = fournisseur;
+    this.requeteur = requeteur;
     this.typeJustificatif = typeJustificatif;
     this.previsualisationRequise = previsualisationRequise;
   }
@@ -80,24 +83,7 @@ class RequeteJustificatif extends Message {
       </rim:Element>
     </rim:SlotValue>
   </rim:Slot>
-  <rim:Slot name="EvidenceRequester">
-    <rim:SlotValue xsi:type="rim:CollectionValueType" collectionType="urn:oasis:names:tc:ebxml-regrep:CollectionType:Set">
-      <rim:Element xsi:type="rim:AnyValueType">
-        <sdg:Agent>
-          <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR">123456</sdg:Identifier>
-          <sdg:Name lang="FR">Un requêteur français</sdg:Name>
-          <sdg:Classification>ER</sdg:Classification>
-        </sdg:Agent>
-      </rim:Element>
-      <rim:Element xsi:type="rim:AnyValueType">
-        <sdg:Agent>
-          <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR">OOTSFRANCE</sdg:Identifier>
-          <sdg:Name lang="EN">OOTS-France Intermediary Platform</sdg:Name>
-          <sdg:Classification>IP</sdg:Classification>
-        </sdg:Agent>
-      </rim:Element>
-    </rim:SlotValue>
-  </rim:Slot>
+  ${this.requeteur.enXML()}
   ${this.fournisseur.enXML()}
   <query:ResponseOption returnType="LeafClassWithRepositoryItem"/>
   <query:Query queryDefinition="DocumentQuery">

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -84,18 +84,16 @@ class RequeteJustificatif extends Message {
     <rim:SlotValue xsi:type="rim:CollectionValueType" collectionType="urn:oasis:names:tc:ebxml-regrep:CollectionType:Set">
       <rim:Element xsi:type="rim:AnyValueType">
         <sdg:Agent>
-          <sdg:Identifier schemeID="urn:cef.eu:names:identifier:EAS:0096">DK22233223</sdg:Identifier>
-          <sdg:Name lang="EN">Denmark University Portal</sdg:Name>
-          <sdg:Address>
-            <sdg:FullAddress>Prince Street 15, 1050 Copenhagen, Denmark</sdg:FullAddress>
-            <sdg:LocatorDesignator>15</sdg:LocatorDesignator>
-            <sdg:PostCode>1050</sdg:PostCode>
-            <sdg:PostCityName>Copenhagen</sdg:PostCityName>
-            <sdg:Thoroughfare>Prince Street</sdg:Thoroughfare>
-            <sdg:AdminUnitLevel1>DK</sdg:AdminUnitLevel1>
-            <sdg:AdminUnitLevel2>DK011</sdg:AdminUnitLevel2>
-          </sdg:Address>
+          <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR">123456</sdg:Identifier>
+          <sdg:Name lang="FR">Un requêteur français</sdg:Name>
           <sdg:Classification>ER</sdg:Classification>
+        </sdg:Agent>
+      </rim:Element>
+      <rim:Element xsi:type="rim:AnyValueType">
+        <sdg:Agent>
+          <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR">OOTSFRANCE</sdg:Identifier>
+          <sdg:Name lang="EN">OOTS-France Intermediary Platform</sdg:Name>
+          <sdg:Classification>IP</sdg:Classification>
         </sdg:Agent>
       </rim:Element>
     </rim:SlotValue>

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -81,7 +81,7 @@ class RequeteJustificatif extends Message {
     </rim:SlotValue>
   </rim:Slot>
   <rim:Slot name="EvidenceRequester">
-    <rim:SlotValue xsi:type="rim:CollectionValueType">
+    <rim:SlotValue xsi:type="rim:CollectionValueType" collectionType="urn:oasis:names:tc:ebxml-regrep:CollectionType:Set">
       <rim:Element xsi:type="rim:AnyValueType">
         <sdg:Agent>
           <sdg:Identifier schemeID="urn:cef.eu:names:identifier:EAS:0096">DK22233223</sdg:Identifier>

--- a/src/ebms/requeteur.js
+++ b/src/ebms/requeteur.js
@@ -1,0 +1,9 @@
+class Requeteur {
+  constructor(donnees = {}) {
+    this.id = donnees.id;
+    this.nom = donnees.nom;
+    this.url = donnees.url;
+  }
+}
+
+module.exports = Requeteur;

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -7,6 +7,7 @@ class ErreurEchecAuthentification extends Error {}
 class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurJetonInvalide extends Error {}
 class ErreurReponseRequete extends Error {}
+class ErreurRequeteurInexistant extends Error {}
 class ErreurTypeJustificatifIntrouvable extends Error {}
 
 module.exports = {
@@ -19,5 +20,6 @@ module.exports = {
   ErreurInstructionSOAPInconnue,
   ErreurJetonInvalide,
   ErreurReponseRequete,
+  ErreurRequeteurInexistant,
   ErreurTypeJustificatifIntrouvable,
 };

--- a/src/ootsFrance.js
+++ b/src/ootsFrance.js
@@ -11,6 +11,7 @@ const creeServeur = (config) => {
     adaptateurEnvironnement,
     adaptateurUUID,
     depotPointsAcces,
+    depotRequeteurs,
     depotServicesCommuns,
     ecouteurDomibus,
     horodateur,
@@ -29,6 +30,7 @@ const creeServeur = (config) => {
     adaptateurEnvironnement,
     adaptateurUUID,
     depotPointsAcces,
+    depotRequeteurs,
     depotServicesCommuns,
   }));
 

--- a/src/routes/routesEbms.js
+++ b/src/routes/routesEbms.js
@@ -2,6 +2,7 @@ const express = require('express');
 
 const EnteteErreur = require('../ebms/enteteErreur');
 const EnteteRequete = require('../ebms/enteteRequete');
+const Fournisseur = require('../ebms/fournisseur');
 const PointAcces = require('../ebms/pointAcces');
 const ReponseErreur = require('../ebms/reponseErreur');
 const ReponseVerificationSysteme = require('../ebms/reponseVerificationSysteme');
@@ -28,7 +29,15 @@ const routesEbms = (config) => {
   });
 
   routes.get('/messages/requeteJustificatif', (_requete, reponse) => {
-    const requeteJustificatif = new RequeteJustificatif({ adaptateurUUID, horodateur });
+    const requeteJustificatif = new RequeteJustificatif(
+      { adaptateurUUID, horodateur },
+      {
+        fournisseur: new Fournisseur({
+          pointAcces: { id: 'unIdentifiant', typeId: 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR' },
+          descriptions: { FR: 'Un requêteur' },
+        }),
+      },
+    );
 
     reponse.set('Content-Type', 'text/xml');
     reponse.send(requeteJustificatif.corpsMessageEnXML());

--- a/src/routes/routesRequete.js
+++ b/src/routes/routesRequete.js
@@ -8,6 +8,7 @@ const routesRequete = (config) => {
     adaptateurEnvironnement,
     adaptateurUUID,
     depotPointsAcces,
+    depotRequeteurs,
     depotServicesCommuns,
   } = config;
 
@@ -20,6 +21,7 @@ const routesRequete = (config) => {
           adaptateurDomibus,
           adaptateurUUID,
           depotPointsAcces,
+          depotRequeteurs,
           depotServicesCommuns,
         },
         requete,

--- a/test/depots/depotRequeteurs.spec.js
+++ b/test/depots/depotRequeteurs.spec.js
@@ -1,0 +1,28 @@
+const { ErreurRequeteurInexistant } = require('../../src/erreurs');
+const DepotRequeteurs = require('../../src/depots/depotRequeteurs');
+
+describe('Le dépôt des requêteurs', () => {
+  it('sait retrouver un requêteur en fonction de son identifiant', () => {
+    const depot = new DepotRequeteurs({
+      123: { nom: 'un requêteur', url: 'http://example.com' },
+    });
+
+    return depot.trouveRequeteur('123')
+      .then((requeteur) => {
+        expect(requeteur.id).toBe('123');
+        expect(requeteur.nom).toBe('un requêteur');
+        expect(requeteur.url).toBe('http://example.com');
+      });
+  });
+
+  it("retourne une exception si le requêteur n'existe pas", () => {
+    expect.assertions(2);
+    const depot = new DepotRequeteurs({});
+
+    return depot.trouveRequeteur('123')
+      .catch((e) => {
+        expect(e).toBeInstanceOf(ErreurRequeteurInexistant);
+        expect(e.message).toBe('Le requêteur avec comme identifiant "123" est inexistant');
+      });
+  });
+});

--- a/test/ebms/requeteur.spec.js
+++ b/test/ebms/requeteur.spec.js
@@ -1,18 +1,16 @@
-class Requeteur {
-  constructor(donnees = {}) {
-    this.id = donnees.id;
-    this.nom = donnees.nom;
-    this.url = donnees.url;
-  }
+const Requeteur = require('../../src/ebms/requeteur');
 
-  enXML() {
-    return `
+describe('Un requêteur', () => {
+  it("s'affiche en XML", () => {
+    const requeteur = new Requeteur({ id: '123456', nom: 'Un requêteur français' });
+
+    expect(requeteur.enXML()).toBe(`
 <rim:Slot name="EvidenceRequester">
   <rim:SlotValue xsi:type="rim:CollectionValueType" collectionType="urn:oasis:names:tc:ebxml-regrep:CollectionType:Set">
     <rim:Element xsi:type="rim:AnyValueType">
       <sdg:Agent>
-        <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR">${this.id}</sdg:Identifier>
-        <sdg:Name lang="FR">${this.nom}</sdg:Name>
+        <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR">123456</sdg:Identifier>
+        <sdg:Name lang="FR">Un requêteur français</sdg:Name>
         <sdg:Classification>ER</sdg:Classification>
       </sdg:Agent>
     </rim:Element>
@@ -25,8 +23,6 @@ class Requeteur {
     </rim:Element>
   </rim:SlotValue>
 </rim:Slot>
-    `;
-  }
-}
-
-module.exports = Requeteur;
+    `);
+  });
+});

--- a/test/routes/serveurTest.js
+++ b/test/routes/serveurTest.js
@@ -1,6 +1,7 @@
 const { ErreurAbsenceReponseDestinataire } = require('../../src/erreurs');
 const OOTS_FRANCE = require('../../src/ootsFrance');
 const Fournisseur = require('../../src/ebms/fournisseur');
+const Requeteur = require('../../src/ebms/requeteur');
 const TypeJustificatif = require('../../src/ebms/typeJustificatif');
 
 const serveurTest = () => {
@@ -8,6 +9,7 @@ const serveurTest = () => {
   let adaptateurEnvironnement;
   let adaptateurUUID;
   let depotPointsAcces;
+  let depotRequeteurs;
   let depotServicesCommuns;
   let ecouteurDomibus;
   let horodateur;
@@ -37,6 +39,10 @@ const serveurTest = () => {
       trouvePointAcces: () => Promise.resolve({}),
     };
 
+    depotRequeteurs = {
+      trouveRequeteur: () => Promise.resolve(new Requeteur()),
+    };
+
     depotServicesCommuns = {
       trouveFournisseurs: () => Promise.resolve([new Fournisseur()]),
       trouveTypeJustificatif: () => Promise.resolve({}),
@@ -58,6 +64,7 @@ const serveurTest = () => {
       adaptateurEnvironnement,
       adaptateurUUID,
       depotPointsAcces,
+      depotRequeteurs,
       depotServicesCommuns,
       ecouteurDomibus,
       horodateur,
@@ -74,6 +81,7 @@ const serveurTest = () => {
     adaptateurUUID: () => adaptateurUUID,
     arrete,
     depotPointsAcces: () => depotPointsAcces,
+    depotRequeteurs: () => depotRequeteurs,
     depotServicesCommuns: () => depotServicesCommuns,
     ecouteurDomibus: () => ecouteurDomibus,
     horodateur: () => horodateur,


### PR DESCRIPTION
On introduit dans cette PR la notion de `DepotRequeteurs`, qui peut retrouver les infos d'un `Requeteur` à partir d'un identifiant passé par le `GET /requete/pieceJustificative`. Ce `Requeteur` se charge de s'afficher en XML dans la requête ebMS passée à Domibus.