### PR TITLE
[CORRECTION] Suppression des `expect` dans le code de production

### DIFF
--- a/src/ebms/utils.js
+++ b/src/ebms/utils.js
@@ -5,13 +5,13 @@ const parseXML = (...args) => (
 );
 
 const verifiePresenceSlot = (nomSlot, scopeRecherche) => {
-  expect(scopeRecherche).toBeDefined();
+  if (typeof scopeRecherche === 'undefined') { throw new Error('Le périmètre de recherche est introuvable.'); }
 
   const sectionSlots = scopeRecherche.Slot;
-  expect(sectionSlots).toBeDefined();
+  if (typeof sectionSlots === 'undefined') { throw new Error('Aucun slot trouvé pour le périmètre de recherche.'); }
 
   const slots = [].concat(sectionSlots);
-  expect(slots.some((s) => s['@_name'] === nomSlot)).toBe(true);
+  if (slots.every((s) => s['@_name'] !== nomSlot)) { throw new Error(`Aucun slot nommé ${nomSlot} trouvé.`); }
 };
 
 const valeurSlot = (nomSlot, scopeRecherche) => {


### PR DESCRIPTION
Ce code était utilisé dans les tests et a été déporté récemment vers `src` pour pouvoir également être utilisé dans le code de production. La présence de mots-clefs `expect` générait une erreur au runtime – non détectée par les tests.

Ce commit corrige le problème.