### PR TITLE
[CORRECTION] Initialisation `requestId` avec la bonne valeur

### DIFF
--- a/src/domibus/enteteMessageRecu.js
+++ b/src/domibus/enteteMessageRecu.js
@@ -20,7 +20,8 @@ class EnteteMessageRecu {
   }
 
   idMessage() {
-    return this.enteteMessageUtilisateur.MessageInfo.MessageId;
+    const idMessage = this.enteteMessageUtilisateur.MessageInfo.MessageId;
+    return idMessage.replace(/@.*$/, '');
   }
 
   idPayload(typeMime) {

--- a/test/domibus/enteteMessageRecu.spec.js
+++ b/test/domibus/enteteMessageRecu.spec.js
@@ -4,6 +4,9 @@ describe('Un entête de message Domibus reçu', () => {
   const donnees = {
     Messaging: {
       UserMessage: {
+        MessageInfo: {
+          MessageId: '00000000-0000-0000-0000-000000000000@domibus.eu',
+        },
         PayloadInfo: {
           PartInfo: [{
             '@_href': 'cid:11111111-1111-1111-1111-111111111111@regrep.oots.eu',
@@ -16,6 +19,11 @@ describe('Un entête de message Domibus reçu', () => {
       },
     },
   };
+
+  it("retourne l'identifiant du message en supprimant le suffixe", () => {
+    const entete = new EnteteMessageRecu(donnees);
+    expect(entete.idMessage()).toBe('00000000-0000-0000-0000-000000000000');
+  });
 
   it("retrouve l'identifiant du payload associé à un type MIME donné", () => {
     const entete = new EnteteMessageRecu(donnees);

--- a/test/domibus/reponseRecuperationMessage.spec.js
+++ b/test/domibus/reponseRecuperationMessage.spec.js
@@ -45,13 +45,13 @@ describe('La réponse à une requête Domibus de récupération de message', () 
     expect(reponse.expediteur().typeId).toEqual('unType');
   });
 
-  it('connaît son identifiant de message', () => {
+  it('connaît son identifiant de message (le UUID, moins le suffixe)', () => {
     const enveloppeSOAP = ConstructeurEnveloppeSOAPException.erreurAutorisationRequise()
       .avecIdMessage('11111111-1111-1111-1111-111111111111@oots.eu')
       .construis();
     const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
 
-    expect(reponse.idMessage()).toEqual('11111111-1111-1111-1111-111111111111@oots.eu');
+    expect(reponse.idMessage()).toEqual('11111111-1111-1111-1111-111111111111');
   });
 
   it('connaît son identifiant de payload du message EBMS', () => {


### PR DESCRIPTION
… c'est-à-dire, sans le suffixe `@…` – pour se conformer au validateur ebMS.

<img width="653" alt="Screenshot 2024-11-04 at 18 20 09" src="https://github.com/user-attachments/assets/b3b7e3e4-ebb0-4eb1-a2fd-39d65f0ce9b4">
