### PR TITLE
[CORRECTION] Initialisation `requestId` avec la bonne valeur

### DIFF
--- a/src/domibus/enteteMessageRecu.js
+++ b/src/domibus/enteteMessageRecu.js
@@ -19,10 +19,6 @@ class EnteteMessageRecu {
     return this.enteteMessageUtilisateur.CollaborationInfo.ConversationId;
   }
 
-  idMessage() {
-    return this.enteteMessageUtilisateur.MessageInfo.MessageId;
-  }
-
   idPayload(typeMime) {
     const infosPayloadMessageEBMS = this.infosPayloads.find((i) => {
       const proprietes = [].concat(i.PartProperties.Property);

--- a/src/domibus/enteteMessageRecu.js
+++ b/src/domibus/enteteMessageRecu.js
@@ -20,8 +20,7 @@ class EnteteMessageRecu {
   }
 
   idMessage() {
-    const idMessage = this.enteteMessageUtilisateur.MessageInfo.MessageId;
-    return idMessage.replace(/@.*$/, '');
+    return this.enteteMessageUtilisateur.MessageInfo.MessageId;
   }
 
   idPayload(typeMime) {

--- a/src/domibus/messageRecu.js
+++ b/src/domibus/messageRecu.js
@@ -1,6 +1,12 @@
+const { ErreurAttributInconnu } = require('../erreurs');
+
 class MessageRecu {
   constructor(xmlParse) {
     this.xmlParse = xmlParse;
+  }
+
+  idRequete() {
+    throw new ErreurAttributInconnu(`Pas d'identifiant de requête dans un message Domibus de type ${this.constructor.name}`);
   }
 
   static idRequeteur = (xmlRequeteur) => xmlRequeteur.Identifier['#text']?.toString();

--- a/src/domibus/reponseRecuperationMessage.js
+++ b/src/domibus/reponseRecuperationMessage.js
@@ -30,8 +30,8 @@ class ReponseRecuperationMessage extends ReponseDomibus {
     return this.entete.idConversation();
   }
 
-  idMessage() {
-    return this.entete.idMessage();
+  idRequete() {
+    return this.corpsMessage.idRequete();
   }
 
   idRequeteur() {
@@ -57,7 +57,7 @@ class ReponseRecuperationMessage extends ReponseDomibus {
       {
         destinataire: this.expediteur(),
         idConversation: this.idConversation(),
-        idRequete: this.idMessage(),
+        idRequete: this.idRequete(),
         requeteur: this.requeteur(),
       },
     );

--- a/src/domibus/requete.js
+++ b/src/domibus/requete.js
@@ -10,6 +10,10 @@ class Requete extends MessageRecu {
     return valeurSlot('Procedure', this.xmlParse.QueryRequest).LocalizedString['@_value'];
   }
 
+  idRequete() {
+    return this.xmlParse.QueryRequest['@_id'];
+  }
+
   reponse(config, donnees) {
     if (this.codeDemarche() === CodeDemarche.VERIFICATION_SYSTEME) {
       return new ReponseVerificationSysteme(config, donnees);

--- a/src/ebms/reponseErreur.js
+++ b/src/ebms/reponseErreur.js
@@ -45,7 +45,7 @@ class ReponseErreur extends Message {
                      xmlns:rs="urn:oasis:names:tc:ebxml-regrep:xsd:rs:4.0"
                      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                      xmlns:xlink="http://www.w3.org/1999/xlink"
-                     requestId="urn:uuid:${this.idRequete}"
+                     requestId="${this.idRequete}"
                      status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Failure">
 
   <rim:Slot name="SpecificationIdentifier">

--- a/src/ebms/reponseVerificationSysteme.js
+++ b/src/ebms/reponseVerificationSysteme.js
@@ -27,7 +27,7 @@ class ReponseVerificationSysteme extends Message {
         xmlns:xlink="http://www.w3.org/1999/xlink"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         status="urn:oasis:names:tc:ebxml-regrep:ResponseStatusType:Success"
-        requestId="urn:uuid:${this.idRequete}">
+        requestId="${this.idRequete}">
 
   <rim:Slot name="SpecificationIdentifier">
     <rim:SlotValue xsi:type="rim:StringValueType">

--- a/src/erreurs.js
+++ b/src/erreurs.js
@@ -5,6 +5,9 @@ class ErreurInstructionSOAPInconnue extends Error {}
 class ErreurJetonInvalide extends Error {}
 class ErreurReponseRequete extends Error {}
 
+class ErreurDomibus extends Error {}
+class ErreurAttributInconnu extends ErreurDomibus {}
+
 class ErreurEBMS extends Error {}
 class ErreurCodeDemarcheIntrouvable extends ErreurEBMS {}
 class ErreurCodePaysIntrouvable extends ErreurEBMS {}
@@ -14,6 +17,7 @@ class ErreurTypeJustificatifIntrouvable extends ErreurEBMS {}
 
 module.exports = {
   ErreurAbsenceReponseDestinataire,
+  ErreurAttributInconnu,
   ErreurAucunMessageDomibusRecu,
   ErreurCodeDemarcheIntrouvable,
   ErreurCodePaysIntrouvable,

--- a/test/constructeurs/constructeurEnveloppeSOAPRequete.js
+++ b/test/constructeurs/constructeurEnveloppeSOAPRequete.js
@@ -2,11 +2,17 @@ class ConstructeurEnveloppeSOAPRequete {
   constructor() {
     this.idPayload = 'cid:99999999-9999-9999-9999-999999999999@oots.eu';
     this.codeDemarche = '';
+    this.idRequete = '';
     this.requeteur = { id: '', nom: '' };
   }
 
   avecCodeDemarche(codeDemarche) {
     this.codeDemarche = codeDemarche;
+    return this;
+  }
+
+  avecIdRequete(id) {
+    this.idRequete = id;
     return this;
   }
 
@@ -27,7 +33,7 @@ class ConstructeurEnveloppeSOAPRequete {
           xmlns:xlink="http://www.w3.org/1999/xlink"
           xmlns:xml="http://www.w3.org/XML/1998/namespace"
           xml:lang="EN"
-          id="urn:uuid:766d83a5-f753-4926-9603-cc9280f7651c">
+          id="${this.idRequete}">
 
   <rim:Slot name="SpecificationIdentifier"><!-- … --></rim:Slot>
   <rim:Slot name="IssueDateTime"><!-- … --></rim:Slot>

--- a/test/constructeurs/constructeurXMLParseRequeteRecue.js
+++ b/test/constructeurs/constructeurXMLParseRequeteRecue.js
@@ -4,6 +4,7 @@ class ConstructeurXMLParseRequeteRecue extends ConstructeurXMLParseMessageRecu {
   constructor() {
     super();
     this.codeDemarche = '';
+    this.idRequete = '';
   }
 
   avecCodeDemarche(codeDemarche) {
@@ -11,9 +12,15 @@ class ConstructeurXMLParseRequeteRecue extends ConstructeurXMLParseMessageRecu {
     return this;
   }
 
+  avecIdRequete(id) {
+    this.idRequete = id;
+    return this;
+  }
+
   construis() {
     return {
       QueryRequest: {
+        '@_id': this.idRequete,
         Slot: [
           {
             '@_name': 'SpecificationIdentifier',

--- a/test/domibus/enteteMessageRecu.spec.js
+++ b/test/domibus/enteteMessageRecu.spec.js
@@ -4,9 +4,6 @@ describe('Un entête de message Domibus reçu', () => {
   const donnees = {
     Messaging: {
       UserMessage: {
-        MessageInfo: {
-          MessageId: '00000000-0000-0000-0000-000000000000@domibus.eu',
-        },
         PayloadInfo: {
           PartInfo: [{
             '@_href': 'cid:11111111-1111-1111-1111-111111111111@regrep.oots.eu',
@@ -19,11 +16,6 @@ describe('Un entête de message Domibus reçu', () => {
       },
     },
   };
-
-  it("retourne l'identifiant du message en supprimant le suffixe", () => {
-    const entete = new EnteteMessageRecu(donnees);
-    expect(entete.idMessage()).toBe('00000000-0000-0000-0000-000000000000');
-  });
 
   it("retrouve l'identifiant du payload associé à un type MIME donné", () => {
     const entete = new EnteteMessageRecu(donnees);

--- a/test/domibus/messageRecu.spec.js
+++ b/test/domibus/messageRecu.spec.js
@@ -1,0 +1,15 @@
+const { ErreurAttributInconnu } = require('../../src/erreurs');
+const MessageRecu = require('../../src/domibus/messageRecu');
+
+describe('Un message reçu de domibus', () => {
+  it("n'a pas d'identifiant de requête par défaut", () => {
+    const messageDomibus = new MessageRecu();
+    try {
+      messageDomibus.idRequete();
+      throw new Error("L'appel à `idRequete` aurait dû lever une exception");
+    } catch (e) {
+      expect(e).toBeInstanceOf(ErreurAttributInconnu);
+      expect(e.message).toBe("Pas d'identifiant de requête dans un message Domibus de type MessageRecu");
+    }
+  });
+});

--- a/test/domibus/reponseRecuperationMessage.spec.js
+++ b/test/domibus/reponseRecuperationMessage.spec.js
@@ -45,15 +45,6 @@ describe('La réponse à une requête Domibus de récupération de message', () 
     expect(reponse.expediteur().typeId).toEqual('unType');
   });
 
-  it('connaît son identifiant de message', () => {
-    const enveloppeSOAP = ConstructeurEnveloppeSOAPException.erreurAutorisationRequise()
-      .avecIdMessage('11111111-1111-1111-1111-111111111111@oots.eu')
-      .construis();
-    const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
-
-    expect(reponse.idMessage()).toEqual('11111111-1111-1111-1111-111111111111@oots.eu');
-  });
-
   it('connaît son identifiant de payload du message EBMS', () => {
     const enveloppeSOAP = ConstructeurEnveloppeSOAPException.erreurAutorisationRequise()
       .avecIdPayload('cid:11111111-1111-1111-1111-111111111111@oots.eu')
@@ -104,6 +95,15 @@ describe('La réponse à une requête Domibus de récupération de message', () 
 
       const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
       expect(reponse.codeDemarche()).toBe(CodeDemarche.VERIFICATION_SYSTEME);
+    });
+
+    it('connaît son identifiant de requête', () => {
+      const enveloppeSOAP = new ConstructeurEnveloppeSOAPRequete()
+        .avecIdRequete('urn:uuid:11111111-1111-1111-1111-111111111111')
+        .construis();
+      const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
+
+      expect(reponse.idRequete()).toEqual('urn:uuid:11111111-1111-1111-1111-111111111111');
     });
 
     it('connaît le requêteur', () => {

--- a/test/domibus/reponseRecuperationMessage.spec.js
+++ b/test/domibus/reponseRecuperationMessage.spec.js
@@ -45,13 +45,13 @@ describe('La réponse à une requête Domibus de récupération de message', () 
     expect(reponse.expediteur().typeId).toEqual('unType');
   });
 
-  it('connaît son identifiant de message (le UUID, moins le suffixe)', () => {
+  it('connaît son identifiant de message', () => {
     const enveloppeSOAP = ConstructeurEnveloppeSOAPException.erreurAutorisationRequise()
       .avecIdMessage('11111111-1111-1111-1111-111111111111@oots.eu')
       .construis();
     const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
 
-    expect(reponse.idMessage()).toEqual('11111111-1111-1111-1111-111111111111');
+    expect(reponse.idMessage()).toEqual('11111111-1111-1111-1111-111111111111@oots.eu');
   });
 
   it('connaît son identifiant de payload du message EBMS', () => {

--- a/test/domibus/requete.spec.js
+++ b/test/domibus/requete.spec.js
@@ -13,6 +13,15 @@ describe('Une action de requête reçue depuis Domibus', () => {
     horodateur.maintenant = () => '';
   });
 
+  it("connaît l'identifiant de la requête", () => {
+    const xmlParse = new ConstructeurXMLParseRequeteRecue()
+      .avecIdRequete('urn:uuid:12345678-1234-1234-1234-1234567890ab')
+      .construis();
+    const requete = new Requete(xmlParse);
+
+    expect(requete.idRequete()).toBe('urn:uuid:12345678-1234-1234-1234-1234567890ab');
+  });
+
   it('connaît le code de la démarche', () => {
     const xmlParse = new ConstructeurXMLParseRequeteRecue()
       .avecCodeDemarche('UN_CODE')

--- a/test/ebms/reponseErreur.spec.js
+++ b/test/ebms/reponseErreur.spec.js
@@ -12,7 +12,7 @@ describe('Une réponse EBMS en erreur', () => {
   });
 
   it("injecte l'identifiant unique de requête", () => {
-    const reponse = new ReponseErreur(config, { idRequete: '11111111-1111-1111-1111-111111111111' });
+    const reponse = new ReponseErreur(config, { idRequete: 'urn:uuid:11111111-1111-1111-1111-111111111111' });
 
     const xml = parseXML(reponse.corpsMessageEnXML());
     const idRequete = xml.QueryResponse['@_requestId'];


### PR DESCRIPTION
Finalement, ce n'est pas l'identifiant du message de la requête (renseigné dans l'entête de l'enveloppe SOAP) qu'il faut reporter dans le paramètre `requestId` de la réponse, mais l'identifiant présent comme attribut `id` dans la balise `QueryRequest` (renseigné dans le corps de message de l'enveloppe SOAP).

Cette PR corrige le problème.