### PR TITLE
[CORRECTION] Retourner une liste, même si la collection ebMS ne contient qu'un élément

### DIFF
--- a/src/ebms/utils.js
+++ b/src/ebms/utils.js
@@ -22,7 +22,7 @@ const valeurSlot = (nomSlot, scopeRecherche) => {
 
   switch (slot['@_type']) {
     case 'rim:AnyValueType': return slot;
-    case 'rim:CollectionValueType': return slot.Element;
+    case 'rim:CollectionValueType': return [].concat(slot.Element);
     default: return slot.Value;
   }
 };

--- a/test/ebms/reponseVerificationSysteme.spec.js
+++ b/test/ebms/reponseVerificationSysteme.spec.js
@@ -55,7 +55,7 @@ describe('Reponse Verification Systeme', () => {
     const scopeRecherche = xml.QueryResponse;
     verifiePresenceSlot('EvidenceProvider', scopeRecherche);
 
-    const fournisseur = valeurSlot('EvidenceProvider', scopeRecherche).Agent;
+    const fournisseur = valeurSlot('EvidenceProvider', scopeRecherche)[0].Agent;
     expect(fournisseur).toBeDefined();
     expect(fournisseur.Identifier).toBeDefined();
     expect(fournisseur.Identifier['@_schemeID']).toBe('urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR');

--- a/test/ebms/utils.spec.js
+++ b/test/ebms/utils.spec.js
@@ -1,0 +1,36 @@
+const { valeurSlot } = require('../../src/ebms/utils');
+
+describe('`valeurSlot` pour un slot de type `rim:CollectionValueType`', () => {
+  it('retourne une liste', () => {
+    const xmlParse = {
+      Slot: [{
+        '@_name': 'Chaines',
+        SlotValue: {
+          '@_type': 'rim:CollectionValueType',
+          Element: [
+            { Chaine: 'Un truc' },
+            { Chaine: 'Un autre truc' },
+          ],
+        },
+      }],
+    };
+
+    const chaines = valeurSlot('Chaines', xmlParse).map((v) => v.Chaine);
+    expect(chaines).toEqual(['Un truc', 'Un autre truc']);
+  });
+
+  it("retourne une liste, même s'il n'y a qu'un seul élément dans la collection", () => {
+    const xmlParse = {
+      Slot: [{
+        '@_name': 'Chaines',
+        SlotValue: {
+          '@_type': 'rim:CollectionValueType',
+          Element: { Chaine: 'Un truc' },
+        },
+      }],
+    };
+
+    const chaines = valeurSlot('Chaines', xmlParse).map((v) => v.Chaine);
+    expect(chaines).toEqual(['Un truc']);
+  });
+});


### PR DESCRIPTION
À l'heure actuelle, on renvoie toujours le contenu de `Element`, qui avec le parser XML qu'on utilise, peut renvoyer un objet ou une liste, suivant qu'il y a 1 ou n éléments.

Cela pose problème quand on fait un `map` sur ce qui est une liste ou pas, et qui peut lever une erreur. C'est ce qui arrive pour les états membres qui ne saisissent qu'un seul requêteur (là où la doc suggère d'ajouter aussi le requêteur de la plate-forme intermédiaire).

Ce commit corrige l'anomalie.