### PR TITLE
Corrige type identifiant Domibus

### DIFF
--- a/exemples/configuration_PMode_Domibus.xml
+++ b/exemples/configuration_PMode_Domibus.xml
@@ -12,7 +12,7 @@
 
     <parties>
       <partyIdTypes>
-        <partyIdType name="partyTypeUrn" value="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator"/>
+        <partyIdType name="partyTypeUrn" value="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots"/>
       </partyIdTypes>
       <party name="blue_gw" endpoint="http://localhost:8080/domibus/services/msh" allowChunking="false">
         <identifier partyId="blue_gw" partyIdType="partyTypeUrn"/>

--- a/src/routes/routesEbms.js
+++ b/src/routes/routesEbms.js
@@ -15,8 +15,10 @@ const routesEbms = (config) => {
   const routes = express.Router();
 
   routes.get('/entetes/requeteJustificatif', (requete, reponse) => {
-    const { idDestinataire, typeIdentifiant } = requete.query;
-    const destinataire = new PointAcces(idDestinataire, typeIdentifiant);
+    const destinataire = new PointAcces(
+      process.env.IDENTIFIANT_EXPEDITEUR_DOMIBUS,
+      process.env.TYPE_IDENTIFIANT_EXPEDITEUR_DOMIBUS,
+    );
     const idConversation = adaptateurUUID.genereUUID();
     const suffixe = process.env.SUFFIXE_IDENTIFIANTS_DOMIBUS;
     const idPayload = `cid:${adaptateurUUID.genereUUID()}@${suffixe}`;

--- a/test/constructeurs/constructeurEnveloppeSOAPAvecPieceJointe.js
+++ b/test/constructeurs/constructeurEnveloppeSOAPAvecPieceJointe.js
@@ -67,11 +67,11 @@ class ConstructeurEnveloppeSOAPAvecPieceJointe {
         </eb:MessageInfo>
         <eb:PartyInfo>
           <eb:From>
-            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator">AP_SI_01</eb:PartyId>
+            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots">AP_SI_01</eb:PartyId>
             <eb:Role>http://sdg.europa.eu/edelivery/gateway</eb:Role>
           </eb:From>
           <eb:To>
-            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator">AP_FR_01</eb:PartyId>
+            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots">AP_FR_01</eb:PartyId>
             <eb:Role>http://sdg.europa.eu/edelivery/gateway</eb:Role>
           </eb:To>
         </eb:PartyInfo>

--- a/test/constructeurs/constructeurEnveloppeSOAPRequete.js
+++ b/test/constructeurs/constructeurEnveloppeSOAPRequete.js
@@ -87,11 +87,11 @@ class ConstructeurEnveloppeSOAPRequete {
         </eb:MessageInfo>
         <eb:PartyInfo>
           <eb:From>
-            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator">AP_SI_01</eb:PartyId>
+            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots">AP_SI_01</eb:PartyId>
             <eb:Role>http://sdg.europa.eu/edelivery/gateway</eb:Role>
           </eb:From>
           <eb:To>
-            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator">AP_FR_01</eb:PartyId>
+            <eb:PartyId type="urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots">AP_FR_01</eb:PartyId>
             <eb:Role>http://sdg.europa.eu/edelivery/gateway</eb:Role>
           </eb:To>
         </eb:PartyInfo>

--- a/test/depots/depotPointsAcces.spec.js
+++ b/test/depots/depotPointsAcces.spec.js
@@ -6,7 +6,7 @@ class ConstructeurPointAcces {
   constructor() {
     this.nom = adaptateurUUID.genereUUID();
     this.id = this.nom;
-    this.typeIdentifiant = 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator';
+    this.typeIdentifiant = 'urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots';
   }
 
   avecId(id) {


### PR DESCRIPTION
Jusqu'ici, on utilise comme typeId la valeur `urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots-simulator`… considéré comme invalide par les validateurs fournis par la Commission Européenne.

Ce commit fait apparaître comme typeId la valeur acceptée `urn:oasis:names:tc:ebcore:partyid-type:unregistered:oots`.

(Corrige issue #39)

⚠️ Une fois ce changement reversé dans `main`, il faudra modifier en local le fichier (non versionné) `.env.oots`, et mettre à jour la configuration PMode dans Domibus.