### PR TITLE
Injection du demandeur dans la réponse

### DIFF
--- a/src/domibus/reponseRecuperationMessage.js
+++ b/src/domibus/reponseRecuperationMessage.js
@@ -22,6 +22,10 @@ class ReponseRecuperationMessage extends ReponseDomibus {
     return this.corpsMessage.codeDemarche();
   }
 
+  demandeur() {
+    return this.corpsMessage.demandeur();
+  }
+
   expediteur() {
     return this.entete.expediteur();
   }
@@ -55,6 +59,7 @@ class ReponseRecuperationMessage extends ReponseDomibus {
     return this.corpsMessage.reponse(
       config,
       {
+        demandeur: this.demandeur(),
         destinataire: this.expediteur(),
         idConversation: this.idConversation(),
         idRequete: this.idRequete(),

--- a/src/domibus/requete.js
+++ b/src/domibus/requete.js
@@ -1,6 +1,7 @@
 const MessageRecu = require('./messageRecu');
 const CodeDemarche = require('../ebms/codeDemarche');
 const ReponseErreur = require('../ebms/reponseErreur');
+const PersonnePhysique = require('../ebms/personnePhysique');
 const ReponseVerificationSysteme = require('../ebms/reponseVerificationSysteme');
 const Requeteur = require('../ebms/requeteur');
 const { valeurSlot } = require('../ebms/utils');
@@ -8,6 +9,17 @@ const { valeurSlot } = require('../ebms/utils');
 class Requete extends MessageRecu {
   codeDemarche() {
     return valeurSlot('Procedure', this.xmlParse.QueryRequest).LocalizedString['@_value'];
+  }
+
+  demandeur() {
+    const demandeur = valeurSlot('NaturalPerson', this.xmlParse.QueryRequest.Query).Person;
+
+    return new PersonnePhysique({
+      dateNaissance: demandeur.DateOfBirth,
+      identifiantEidas: demandeur.Identifier?.['#text'],
+      nom: demandeur.FamilyName,
+      prenom: demandeur.GivenName,
+    });
   }
 
   idRequete() {

--- a/src/ebms/personnePhysique.js
+++ b/src/ebms/personnePhysique.js
@@ -6,24 +6,42 @@ class PersonnePhysique {
     this.dateNaissance = donnees.dateNaissance;
   }
 
-  enXML() {
+  attributsEnXML() {
     const identifiantEidasEnXML = typeof this.identifiantEidas !== 'undefined'
       ? `<sdg:Identifier schemeID="eidas">${this.identifiantEidas}</sdg:Identifier>`
       : '';
 
     return `
+${identifiantEidasEnXML}
+<sdg:FamilyName>${this.nom}</sdg:FamilyName>
+<sdg:GivenName>${this.prenom}</sdg:GivenName>
+<sdg:DateOfBirth>${this.dateNaissance}</sdg:DateOfBirth>
+`;
+  }
+
+  enXMLPourReponse() {
+    return `
+<sdg:NaturalPerson>${this.attributsEnXML()}</sdg:NaturalPerson>
+    `;
+  }
+
+  enXML() {
+    return `
 <rim:Slot name="NaturalPerson">
   <rim:SlotValue xsi:type="rim:AnyValueType">
     <sdg:Person>
       <sdg:LevelOfAssurance>High</sdg:LevelOfAssurance>
-      ${identifiantEidasEnXML}
-      <sdg:FamilyName>${this.nom}</sdg:FamilyName>
-      <sdg:GivenName>${this.prenom}</sdg:GivenName>
-      <sdg:DateOfBirth>${this.dateNaissance}</sdg:DateOfBirth>
+${this.attributsEnXML()}
     </sdg:Person>
   </rim:SlotValue>
 </rim:Slot>
     `;
+  }
+
+  identifiantEidasEnXML() {
+    return typeof this.identifiantEidas !== 'undefined'
+      ? `<sdg:Identifier schemeID="eidas">${this.identifiantEidas}</sdg:Identifier>`
+      : '';
   }
 }
 

--- a/src/ebms/personnePhysique.js
+++ b/src/ebms/personnePhysique.js
@@ -25,7 +25,7 @@ ${identifiantEidasEnXML}
     `;
   }
 
-  enXML() {
+  enXMLPourRequete() {
     return `
 <rim:Slot name="NaturalPerson">
   <rim:SlotValue xsi:type="rim:AnyValueType">

--- a/src/ebms/personnePhysique.js
+++ b/src/ebms/personnePhysique.js
@@ -1,16 +1,22 @@
 class PersonnePhysique {
   constructor(donnees = {}) {
+    this.identifiantEidas = donnees.identifiantEidas;
     this.nom = donnees.nom;
     this.prenom = donnees.prenom;
     this.dateNaissance = donnees.dateNaissance;
   }
 
   enXML() {
+    const identifiantEidasEnXML = typeof this.identifiantEidas !== 'undefined'
+      ? `<sdg:Identifier schemeID="eidas">${this.identifiantEidas}</sdg:Identifier>`
+      : '';
+
     return `
 <rim:Slot name="NaturalPerson">
   <rim:SlotValue xsi:type="rim:AnyValueType">
     <sdg:Person>
       <sdg:LevelOfAssurance>High</sdg:LevelOfAssurance>
+      ${identifiantEidasEnXML}
       <sdg:FamilyName>${this.nom}</sdg:FamilyName>
       <sdg:GivenName>${this.prenom}</sdg:GivenName>
       <sdg:DateOfBirth>${this.dateNaissance}</sdg:DateOfBirth>

--- a/src/ebms/reponseVerificationSysteme.js
+++ b/src/ebms/reponseVerificationSysteme.js
@@ -15,6 +15,7 @@ class ReponseVerificationSysteme extends Message {
 
     super(config, { ...donnees, pieceJointe });
 
+    this.demandeur = donnees.demandeur;
     this.idRequete = donnees.idRequete;
     this.requeteur = donnees.requeteur;
   }

--- a/src/ebms/reponseVerificationSysteme.js
+++ b/src/ebms/reponseVerificationSysteme.js
@@ -69,12 +69,7 @@ class ReponseVerificationSysteme extends Message {
           <sdg:Evidence>
             <sdg:Identifier>${this.adaptateurUUID?.genereUUID()}</sdg:Identifier>
             <sdg:IsAbout>
-              <sdg:NaturalPerson>
-                <sdg:Identifier schemeID='eidas'>DK/DE/123123123</sdg:Identifier>
-                <sdg:FamilyName></sdg:FamilyName>
-                <sdg:GivenName></sdg:GivenName>
-                <sdg:DateOfBirth>1970-03-01</sdg:DateOfBirth>
-              </sdg:NaturalPerson>
+              ${this.demandeur.enXMLPourReponse()}
             </sdg:IsAbout>
             <sdg:IssuingAuthority>
               <sdg:Identifier schemeID="urn:oasis:names:tc:ebcore:partyid-type:unregistered:FR"></sdg:Identifier>

--- a/src/ebms/requeteJustificatif.js
+++ b/src/ebms/requeteJustificatif.js
@@ -89,7 +89,7 @@ class RequeteJustificatif extends Message {
   ${this.fournisseur.enXML()}
   <query:ResponseOption returnType="LeafClassWithRepositoryItem"/>
   <query:Query queryDefinition="DocumentQuery">
-    ${this.demandeur.enXML()}
+    ${this.demandeur.enXMLPourRequete()}
     ${this.typeJustificatif.enXML()}
   </query:Query>
 </query:QueryRequest>`;

--- a/src/routes/routesEbms.js
+++ b/src/routes/routesEbms.js
@@ -3,6 +3,7 @@ const express = require('express');
 const EnteteErreur = require('../ebms/enteteErreur');
 const EnteteRequete = require('../ebms/enteteRequete');
 const Fournisseur = require('../ebms/fournisseur');
+const PersonnePhysique = require('../ebms/personnePhysique');
 const PointAcces = require('../ebms/pointAcces');
 const ReponseErreur = require('../ebms/reponseErreur');
 const ReponseVerificationSysteme = require('../ebms/reponseVerificationSysteme');
@@ -75,8 +76,10 @@ const routesEbms = (config) => {
   });
 
   routes.get('/messages/reponseJustificatif', (requete, reponse) => {
+    const demandeur = new PersonnePhysique({ dateNaissance: '1992-10-22', nom: 'Dupont', prenom: 'Jean' });
     const requeteur = new Requeteur({ id: '12345', nom: 'Un requêteur' });
     const reponseJustificatif = new ReponseVerificationSysteme({ adaptateurUUID, horodateur }, {
+      demandeur,
       destinataire: new PointAcces('unTypeIdentifiant', 'unIdentifiant'),
       idRequete: '12345678-1234-1234-1234-1234567890ab',
       idConversation: '12345',

--- a/test/constructeurs/constructeurEnveloppeSOAPRequete.js
+++ b/test/constructeurs/constructeurEnveloppeSOAPRequete.js
@@ -1,13 +1,21 @@
+const PersonnePhysique = require('../../src/ebms/personnePhysique');
+
 class ConstructeurEnveloppeSOAPRequete {
   constructor() {
     this.idPayload = 'cid:99999999-9999-9999-9999-999999999999@oots.eu';
     this.codeDemarche = '';
+    this.demandeur = new PersonnePhysique();
     this.idRequete = '';
     this.requeteur = { id: '', nom: '' };
   }
 
   avecCodeDemarche(codeDemarche) {
     this.codeDemarche = codeDemarche;
+    return this;
+  }
+
+  avecDemandeur(donnees) {
+    this.demandeur = new PersonnePhysique(donnees);
     return this;
   }
 
@@ -69,7 +77,16 @@ class ConstructeurEnveloppeSOAPRequete {
   <rim:Slot name="EvidenceProvider"><!-- … --></rim:Slot>
   <query:ResponseOption returnType="LeafClassWithRepositoryItem"/>
   <query:Query queryDefinition="DocumentQuery">
-    <rim:Slot name="NaturalPerson"><!-- … --></rim:Slot>
+    <rim:Slot name="NaturalPerson">
+      <rim:SlotValue xsi:type="rim:AnyValueType">
+        <sdg:Person>
+          <sdg:LevelOfAssurance>High</sdg:LevelOfAssurance>
+          <sdg:FamilyName>${this.demandeur.nom}</sdg:FamilyName>
+          <sdg:GivenName>${this.demandeur.prenom}</sdg:GivenName>
+          <sdg:DateOfBirth>${this.demandeur.dateNaissance}</sdg:DateOfBirth>
+        </sdg:Person>
+      </rim:SlotValue>
+    </rim:Slot>
     <rim:Slot name="EvidenceRequest"><!-- … --></rim:Slot>
   </query:Query>
 </query:QueryRequest>

--- a/test/constructeurs/constructeurXMLParseRequeteRecue.js
+++ b/test/constructeurs/constructeurXMLParseRequeteRecue.js
@@ -1,14 +1,21 @@
 const ConstructeurXMLParseMessageRecu = require('./constructeurXMLParseMessageRecu');
+const PersonnePhysique = require('../../src/ebms/personnePhysique');
 
 class ConstructeurXMLParseRequeteRecue extends ConstructeurXMLParseMessageRecu {
   constructor() {
     super();
     this.codeDemarche = '';
     this.idRequete = '';
+    this.demandeur = new PersonnePhysique();
   }
 
   avecCodeDemarche(codeDemarche) {
     this.codeDemarche = codeDemarche;
+    return this;
+  }
+
+  avecDemandeur(donnees) {
+    this.demandeur = new PersonnePhysique(donnees);
     return this;
   }
 
@@ -63,6 +70,25 @@ class ConstructeurXMLParseRequeteRecue extends ConstructeurXMLParseMessageRecu {
             },
           },
         ],
+        Query: {
+          Slot: [
+            {
+              '@_name': 'NaturalPerson',
+              SlotValue: {
+                '@_type': 'rim:AnyValueType',
+                Person: {
+                  Identifier: this.demandeur.identifiantEidas && {
+                    '@_schemeID': 'eidas',
+                    '#text': this.demandeur.identifiantEidas,
+                  },
+                  FamilyName: this.demandeur.nom,
+                  GivenName: this.demandeur.prenom,
+                  DateOfBirth: this.demandeur.dateNaissance,
+                },
+              },
+            },
+          ],
+        },
       },
     };
   }

--- a/test/domibus/reponseRecuperationMessage.spec.js
+++ b/test/domibus/reponseRecuperationMessage.spec.js
@@ -128,5 +128,27 @@ describe('La réponse à une requête Domibus de récupération de message', () 
       });
       expect(reponseVerificationSysteme.requeteur).toEqual({ id: '12345', nom: 'Un requêteur' });
     });
+
+    it('connaît le demandeur', () => {
+      const enveloppeSOAP = new ConstructeurEnveloppeSOAPRequete()
+        .avecCodeDemarche(CodeDemarche.VERIFICATION_SYSTEME)
+        .avecDemandeur({ nom: 'Dupont' })
+        .construis();
+
+      const reponse = new ReponseRecuperationMessage(enveloppeSOAP);
+      expect(reponse.demandeur().nom).toBe('Dupont');
+    });
+
+    it('transmet le demandeur à la réponse', () => {
+      const enveloppeSOAP = new ConstructeurEnveloppeSOAPRequete()
+        .avecCodeDemarche(CodeDemarche.VERIFICATION_SYSTEME)
+        .avecDemandeur({ nom: 'Dupont' })
+        .construis();
+
+      const reponseVerificationSysteme = new ReponseRecuperationMessage(enveloppeSOAP).reponse({
+        adaptateurUUID: { genereUUID: () => '' },
+      });
+      expect(reponseVerificationSysteme.demandeur.nom).toEqual('Dupont');
+    });
   });
 });

--- a/test/domibus/requete.spec.js
+++ b/test/domibus/requete.spec.js
@@ -50,6 +50,24 @@ describe('Une action de requête reçue depuis Domibus', () => {
     expect(requete.requeteur().id).toBe('12345');
   });
 
+  it('connaît le demandeur', () => {
+    const xmlParse = new ConstructeurXMLParseRequeteRecue()
+      .avecDemandeur({
+        dateNaissance: '1992-10-22',
+        identifiantEidas: 'DK/DE/123123123',
+        nom: 'Dupont',
+        prenom: 'Jean',
+      })
+      .construis();
+    const requete = new Requete(xmlParse);
+
+    const demandeur = requete.demandeur();
+    expect(demandeur.dateNaissance).toBe('1992-10-22');
+    expect(demandeur.identifiantEidas).toBe('DK/DE/123123123');
+    expect(demandeur.nom).toBe('Dupont');
+    expect(demandeur.prenom).toBe('Jean');
+  });
+
   describe('avec comme démarche une demande de bourse', () => {
     it("transmets l'identifiant de la requête", () => {
       const xmlParse = new ConstructeurXMLParseRequeteRecue()

--- a/test/ebms/personnePhysique.spec.js
+++ b/test/ebms/personnePhysique.spec.js
@@ -12,7 +12,7 @@ describe('Une personne physique', () => {
       },
     );
 
-    expect(jose.enXML()).toBe(`
+    expect(jose.enXMLPourRequete()).toBe(`
 <rim:Slot name="NaturalPerson">
   <rim:SlotValue xsi:type="rim:AnyValueType">
     <sdg:Person>
@@ -31,7 +31,7 @@ describe('Une personne physique', () => {
 
   it("n'affiche pas la balise identifiant s'il n'y a pas d'identifiant renseigné", () => {
     const personneSansIdentifiantEidas = new PersonnePhysique();
-    const xml = parseXML(personneSansIdentifiantEidas.enXML());
+    const xml = parseXML(personneSansIdentifiantEidas.enXMLPourRequete());
     const identifiantEidas = valeurSlot('NaturalPerson', xml).Person.Identifier;
 
     expect(identifiantEidas).toBeUndefined();

--- a/test/ebms/personnePhysique.spec.js
+++ b/test/ebms/personnePhysique.spec.js
@@ -2,8 +2,8 @@ const PersonnePhysique = require('../../src/ebms/personnePhysique');
 const { parseXML, valeurSlot } = require('../../src/ebms/utils');
 
 describe('Une personne physique', () => {
-  it("doit s'afficher en XML", () => {
-    const jonas = new PersonnePhysique(
+  it("s'affiche en XML pour une requête", () => {
+    const jose = new PersonnePhysique(
       {
         identifiantEidas: 'DK/DE/123123123',
         nom: 'Garcia',
@@ -12,15 +12,17 @@ describe('Une personne physique', () => {
       },
     );
 
-    expect(jonas.enXML()).toBe(`
+    expect(jose.enXML()).toBe(`
 <rim:Slot name="NaturalPerson">
   <rim:SlotValue xsi:type="rim:AnyValueType">
     <sdg:Person>
       <sdg:LevelOfAssurance>High</sdg:LevelOfAssurance>
-      <sdg:Identifier schemeID="eidas">DK/DE/123123123</sdg:Identifier>
-      <sdg:FamilyName>Garcia</sdg:FamilyName>
-      <sdg:GivenName>Jose</sdg:GivenName>
-      <sdg:DateOfBirth>1985-12-20</sdg:DateOfBirth>
+
+<sdg:Identifier schemeID="eidas">DK/DE/123123123</sdg:Identifier>
+<sdg:FamilyName>Garcia</sdg:FamilyName>
+<sdg:GivenName>Jose</sdg:GivenName>
+<sdg:DateOfBirth>1985-12-20</sdg:DateOfBirth>
+
     </sdg:Person>
   </rim:SlotValue>
 </rim:Slot>
@@ -33,5 +35,25 @@ describe('Une personne physique', () => {
     const identifiantEidas = valeurSlot('NaturalPerson', xml).Person.Identifier;
 
     expect(identifiantEidas).toBeUndefined();
+  });
+
+  it("s'affiche en XML pour une réponse", () => {
+    const jose = new PersonnePhysique(
+      {
+        identifiantEidas: 'DK/DE/123123123',
+        nom: 'Garcia',
+        prenom: 'Jose',
+        dateNaissance: '1985-12-20',
+      },
+    );
+
+    expect(jose.enXMLPourReponse()).toBe(`
+<sdg:NaturalPerson>
+<sdg:Identifier schemeID="eidas">DK/DE/123123123</sdg:Identifier>
+<sdg:FamilyName>Garcia</sdg:FamilyName>
+<sdg:GivenName>Jose</sdg:GivenName>
+<sdg:DateOfBirth>1985-12-20</sdg:DateOfBirth>
+</sdg:NaturalPerson>
+    `);
   });
 });

--- a/test/ebms/personnePhysique.spec.js
+++ b/test/ebms/personnePhysique.spec.js
@@ -1,9 +1,11 @@
 const PersonnePhysique = require('../../src/ebms/personnePhysique');
+const { parseXML, valeurSlot } = require('../../src/ebms/utils');
 
 describe('Une personne physique', () => {
   it("doit s'afficher en XML", () => {
     const jonas = new PersonnePhysique(
       {
+        identifiantEidas: 'DK/DE/123123123',
         nom: 'Garcia',
         prenom: 'Jose',
         dateNaissance: '1985-12-20',
@@ -15,6 +17,7 @@ describe('Une personne physique', () => {
   <rim:SlotValue xsi:type="rim:AnyValueType">
     <sdg:Person>
       <sdg:LevelOfAssurance>High</sdg:LevelOfAssurance>
+      <sdg:Identifier schemeID="eidas">DK/DE/123123123</sdg:Identifier>
       <sdg:FamilyName>Garcia</sdg:FamilyName>
       <sdg:GivenName>Jose</sdg:GivenName>
       <sdg:DateOfBirth>1985-12-20</sdg:DateOfBirth>
@@ -22,5 +25,13 @@ describe('Une personne physique', () => {
   </rim:SlotValue>
 </rim:Slot>
     `);
+  });
+
+  it("n'affiche pas la balise identifiant s'il n'y a pas d'identifiant renseigné", () => {
+    const personneSansIdentifiantEidas = new PersonnePhysique();
+    const xml = parseXML(personneSansIdentifiantEidas.enXML());
+    const identifiantEidas = valeurSlot('NaturalPerson', xml).Person.Identifier;
+
+    expect(identifiantEidas).toBeUndefined();
   });
 });


### PR DESCRIPTION
L'identité du bénéficiaire – celui pour le compte de qui un fournisseur de service demande une pièce justificative – doit être reportée dans la réponse.

Cette PR honore cette contrainte.

À faire plus tard : 
- Revoir initialisation des données dans `ConstructeurXMLParseMessageRecu#avecRequeteur`
- Peut-être renommer `demandeur` en `bénéficiaire` ?